### PR TITLE
fix: use service_started condition for dependencies without healthcheck

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rdt-rambo"
-version = "1.1.0"
+version = "1.2.0"
 description = "Rambo Docker Tools — CLI for docker-compose generation"
 readme = "README.md"
 license = "MIT"

--- a/rdt/cli.py
+++ b/rdt/cli.py
@@ -17,7 +17,7 @@ from rich import box
 from rdt.presets.catalog import ALL_PRESETS, ServicePreset
 from rdt.strategies.base import NETWORK_NAME
 from rdt.strategies.factory import get_strategy
-from rdt.yaml_manager import load_compose, save_compose, make_base_compose, inject_service, get_existing_services
+from rdt.yaml_manager import load_compose, save_compose, make_base_compose, inject_service, get_existing_services, get_services_with_healthcheck
 from rdt.env_manager import get_env_values, write_env, write_env_example
 from rdt.wizard import run_wizard, run_main_menu, ask_service_choice, build_script_answers
 from rdt.i18n import t
@@ -154,9 +154,11 @@ def add(
     if file.exists():
         data = load_compose(file)
         existing = get_existing_services(data)
+        svc_with_hc = get_services_with_healthcheck(data)
     else:
         data = None
         existing = []
+        svc_with_hc = set()
 
     # Проверить что сервис не добавлен дважды (ключ в services = preset.name)
     svc_key = preset.name
@@ -189,7 +191,10 @@ def add(
             hc_start_period=hc_start_period,
         )
     else:
-        answers = run_wizard(preset, existing, hardcore=hardcore)
+        answers = run_wizard(preset, existing, hardcore=hardcore, services_with_healthcheck=svc_with_hc)
+
+    # Передаём в стратегию информацию о том, у каких сервисов есть healthcheck
+    answers["services_with_healthcheck"] = svc_with_hc
 
     # Создать базовый файл если не существует — с учётом выбранной сети
     if data is None:

--- a/rdt/strategies/base.py
+++ b/rdt/strategies/base.py
@@ -60,8 +60,12 @@ class BaseStrategy(ABC):
 
         # depends_on
         if deps := self.answers.get("depends_on"):
+            svc_with_hc: set[str] = self.answers.get("services_with_healthcheck", set())
             service["depends_on"] = {
-                dep: {"condition": "service_healthy"} for dep in deps
+                dep: {
+                    "condition": "service_healthy" if dep in svc_with_hc else "service_started"
+                }
+                for dep in deps
             }
 
         # Лимиты ресурсов

--- a/rdt/wizard.py
+++ b/rdt/wizard.py
@@ -26,12 +26,14 @@ def run_wizard(
     preset: ServicePreset,
     existing_services: list[str],
     hardcore: bool = False,
+    services_with_healthcheck: set[str] | None = None,
 ) -> dict[str, Any]:
     """
     Запустить интерактивный мастер для выбранного пресета.
     Возвращает словарь answers для передачи в стратегию.
     """
     answers: dict[str, Any] = {}
+    _svc_with_hc = services_with_healthcheck or set()
 
     console.print(t("wizard.configuring", name=preset.display_name))
 
@@ -72,7 +74,7 @@ def run_wizard(
 
     # ── 8. depends_on ────────────────────────────────────────────────────────
     if existing_services:
-        answers["depends_on"] = _ask_depends_on(existing_services)
+        answers["depends_on"] = _ask_depends_on(existing_services, _svc_with_hc)
     else:
         answers["depends_on"] = []
 
@@ -224,14 +226,22 @@ def _ask_volume(preset: ServicePreset) -> str:
         return questionary.text(t("wizard.volume_enter")).ask() or default_named
 
 
-def _ask_depends_on(existing_services: list[str]) -> list[str]:
+def _ask_depends_on(existing_services: list[str], services_with_healthcheck: set[str] | None = None) -> list[str]:
     if not existing_services:
         return []
-    choices = questionary.checkbox(
+    svc_with_hc = services_with_healthcheck or set()
+    choices = [
+        questionary.Choice(
+            title=f"{svc}  [healthcheck ✓]" if svc in svc_with_hc else svc,
+            value=svc,
+        )
+        for svc in existing_services
+    ]
+    selected = questionary.checkbox(
         t("wizard.depends_question"),
-        choices=existing_services,
+        choices=choices,
     ).ask()
-    return choices or []
+    return selected or []
 
 
 def _ask_smart_mapping(

--- a/rdt/yaml_manager.py
+++ b/rdt/yaml_manager.py
@@ -138,6 +138,15 @@ def get_existing_services(data: CommentedMap) -> list[str]:
     return list(data.get("services", {}).keys())
 
 
+def get_services_with_healthcheck(data: CommentedMap) -> set[str]:
+    """Вернуть множество имён сервисов, у которых задан healthcheck."""
+    result: set[str] = set()
+    for svc_name, svc_def in (data.get("services") or {}).items():
+        if svc_def and "healthcheck" in svc_def:
+            result.add(svc_name)
+    return result
+
+
 def _dict_to_commented(d: Any) -> Any:
     """Рекурсивно конвертировать dict → CommentedMap."""
     if isinstance(d, dict):

--- a/templates/admin_tool.yml.j2
+++ b/templates/admin_tool.yml.j2
@@ -23,7 +23,7 @@
   depends_on:
 {% for dep in depends_on %}
     {{ dep }}:
-      condition: service_healthy
+      condition: {{ "service_healthy" if dep in services_with_healthcheck else "service_started" }}
 {% endfor %}
 {% endif %}
   networks:

--- a/templates/database.yml.j2
+++ b/templates/database.yml.j2
@@ -39,7 +39,7 @@
   depends_on:
 {% for dep in depends_on %}
     {{ dep }}:
-      condition: service_healthy
+      condition: {{ "service_healthy" if dep in services_with_healthcheck else "service_started" }}
 {% endfor %}
 {% endif %}
   networks:

--- a/templates/monitoring.yml.j2
+++ b/templates/monitoring.yml.j2
@@ -36,7 +36,7 @@
   depends_on:
 {% for dep in depends_on %}
     {{ dep }}:
-      condition: service_healthy
+      condition: {{ "service_healthy" if dep in services_with_healthcheck else "service_started" }}
 {% endfor %}
 {% endif %}
   networks:


### PR DESCRIPTION
Updated dependency condition logic to check if a service has a healthcheck before using service_healthy. Services without healthchecks now use service_started to avoid docker-compose errors. Added tracking of services with healthchecks across templates, strategies, and wizard, and enhanced dependency selection UI to show which services have healthchecks configured.