### PR TITLE
feat: add `rdt check` command to validate docker-compose.yml

### DIFF
--- a/rdt/cli.py
+++ b/rdt/cli.py
@@ -61,6 +61,9 @@ def _run_interactive() -> None:
             except SystemExit:
                 pass
 
+        elif action == "check":
+            check()
+
         elif action == "up":
             up()
             return
@@ -277,6 +280,34 @@ def up(
     console.print(t("msg.running_cmd", cmd=" ".join(cmd)))
     result = subprocess.run(cmd)
     sys.exit(result.returncode)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# rdt check
+# ─────────────────────────────────────────────────────────────────────────────
+@app.command(help=t("cmd.check.help"))
+def check(
+    file: Annotated[Path, typer.Option("--file", "-f", help=t("cmd.check.opt_file"))] = COMPOSE_FILE,
+    verbose: Annotated[bool, typer.Option("--verbose", "-v", help=t("cmd.check.opt_verbose"))] = False,
+) -> None:
+    if not file.exists():
+        console.print(t("msg.compose_not_found_run", file=file))
+        raise typer.Exit(1)
+
+    cmd = ["docker", "compose", "-f", str(file), "config"]
+    console.print(t("msg.check_running", file=file))
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+
+    if result.returncode == 0:
+        if verbose and result.stdout:
+            console.print(result.stdout.strip())
+        console.print(t("msg.check_ok", file=file))
+    else:
+        if result.stderr:
+            console.print(result.stderr.strip())
+        console.print(t("msg.check_fail", file=file))
+        raise typer.Exit(result.returncode)
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/rdt/locales/en.json
+++ b/rdt/locales/en.json
@@ -24,6 +24,10 @@
 
   "cmd.list.help": "Show all available presets by category.",
 
+  "cmd.check.help": "Validate docker-compose.yml by running docker compose config.\n\nDetects YAML syntax errors, unknown keys, and invalid references\nbefore you run [cyan]rdt up[/].",
+  "cmd.check.opt_file": "Path to docker-compose.yml",
+  "cmd.check.opt_verbose": "Print the resolved compose config on success",
+
   "cmd.up.help": "Run docker compose up (proxy command).",
   "cmd.up.opt_file": "Path to docker-compose.yml",
   "cmd.up.opt_detach": "Detached mode",
@@ -43,6 +47,9 @@
   "msg.env_written": "[green]✓[/] Environment variables written to [bold]{file}[/]",
   "msg.compose_not_found_run": "[red]✗[/] File [bold]{file}[/] not found. Run [cyan]rdt init[/] first",
   "msg.running_cmd": "[cyan]▶[/] Running: [bold]{cmd}[/]\n",
+  "msg.check_running": "[cyan]▶[/] Validating [bold]{file}[/] ...\n",
+  "msg.check_ok": "\n[green]✓[/] [bold]{file}[/] is valid — no errors found.",
+  "msg.check_fail": "\n[red]✗[/] [bold]{file}[/] has errors. Fix them before running [cyan]rdt up[/].",
   "msg.do_more": "Do something else?",
 
   "table.title": "🐳 RDT — Available services",
@@ -59,6 +66,7 @@
   "menu.init": "🗂   Initialize project (rdt init)",
   "menu.list": "📋  Show all available services",
   "menu.up": "🚀  Start containers (docker compose up)",
+  "menu.check": "🔍  Check config (docker compose config)",
   "menu.lang": "🌐  Change language",
   "menu.exit": "❌  Exit",
   "menu.service_choice": "Select a service to add:",

--- a/rdt/locales/ru.json
+++ b/rdt/locales/ru.json
@@ -24,6 +24,10 @@
 
   "cmd.list.help": "Показать все доступные пресеты по категориям.",
 
+  "cmd.check.help": "Валидировать docker-compose.yml через docker compose config.\n\nОбнаруживает ошибки синтаксиса YAML, неизвестные ключи и неверные ссылки\nещё до запуска [cyan]rdt up[/].",
+  "cmd.check.opt_file": "Путь к docker-compose.yml",
+  "cmd.check.opt_verbose": "Показать разрешённый конфиг при успешной проверке",
+
   "cmd.up.help": "Запустить docker compose up (прокси-команда).",
   "cmd.up.opt_file": "Путь к docker-compose.yml",
   "cmd.up.opt_detach": "Фоновый режим",
@@ -43,6 +47,9 @@
   "msg.env_written": "[green]✓[/] Переменные окружения записаны в [bold]{file}[/]",
   "msg.compose_not_found_run": "[red]✗[/] Файл [bold]{file}[/] не найден. Сначала выполните [cyan]rdt init[/]",
   "msg.running_cmd": "[cyan]▶[/] Выполняю: [bold]{cmd}[/]\n",
+  "msg.check_running": "[cyan]▶[/] Проверяю [bold]{file}[/] ...\n",
+  "msg.check_ok": "\n[green]✓[/] [bold]{file}[/] валиден — ошибок не найдено.",
+  "msg.check_fail": "\n[red]✗[/] [bold]{file}[/] содержит ошибки. Исправьте их перед запуском [cyan]rdt up[/].",
   "msg.do_more": "Сделать что-то ещё?",
 
   "table.title": "🐳 RDT — Доступные сервисы",
@@ -59,6 +66,7 @@
   "menu.init": "🗂   Инициализировать проект (rdt init)",
   "menu.list": "📋  Показать все доступные сервисы",
   "menu.up": "🚀  Запустить контейнеры (docker compose up)",
+  "menu.check": "🔍  Проверить конфиг (docker compose config)",
   "menu.lang": "🌐  Сменить язык",
   "menu.exit": "❌  Выход",
   "menu.service_choice": "Выберите сервис для добавления:",

--- a/rdt/wizard.py
+++ b/rdt/wizard.py
@@ -308,6 +308,7 @@ def run_main_menu() -> str:
             questionary.Choice(t("menu.init"),  value="init"),
             questionary.Choice(t("menu.list"),  value="list"),
             questionary.Choice(t("menu.up"),    value="up"),
+            questionary.Choice(t("menu.check"), value="check"),
             questionary.Choice(t("menu.lang"),  value="lang"),
             questionary.Choice(t("menu.exit"),  value="exit"),
         ],


### PR DESCRIPTION
Implement new `check` command that runs `docker compose config` to validate the compose file before deployment. Detects YAML syntax errors, unknown keys, and invalid references. Add `--verbose` flag to optionally print the resolved configuration. Include the command in the interactive menu and provide localized strings for English and Russian.