### PR TITLE
feat: add MCP server for native AI client integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - **Project diagnostics** — `rdt doctor` validates your stack before you start it
 - **Multi-language UI** — English and Russian, switchable at any time
 - **Agentic Skill** — includes dedicated instructions for AI coding agents to use RDT autonomously
+- **MCP Server** — Model Context Protocol server (`rdt-mcp`) for native integration with Claude Desktop, Cursor, Windsurf, and any other MCP-compatible AI client
 
 ---
 
@@ -59,6 +60,9 @@ pipx ensurepath   # add pipx bin dir to PATH (restart terminal after)
 # Install RDT from PyPI
 pipx install rdt-rambo
 
+# With MCP server support
+pipx install "rdt-rambo[mcp]"
+
 # Or install directly from GitHub (no PyPI account needed)
 pipx install git+https://github.com/Skr0ls/RDT.git
 ```
@@ -70,6 +74,9 @@ pipx install git+https://github.com/Skr0ls/RDT.git
 ```bash
 # From PyPI
 pip install rdt-rambo
+
+# With MCP server support
+pip install "rdt-rambo[mcp]"
 
 # Or from GitHub
 pip install git+https://github.com/Skr0ls/RDT.git
@@ -93,8 +100,9 @@ python -m venv .venv
 # macOS / Linux
 source .venv/bin/activate
 
-# 3. Install in editable mode with all dependencies
+# 3. Install in editable mode (add [mcp] for MCP server support)
 pip install -e .
+pip install -e ".[mcp]"
 ```
 
 ---
@@ -300,13 +308,57 @@ RDT_LANG=en rdt add postgres
 
 ## 🤖 AI Agent Integration
 
-RDT is fully compatible with AI coding assistants (Cursor, GitHub Copilot, Augment, etc.) and autonomous agents.
+RDT offers two complementary ways to integrate with AI coding assistants and autonomous agents.
 
-To enable your AI agent to independently scaffold and manage Docker environments using RDT, just point it to the provided skill file:
+---
+
+### Option A — MCP Server (recommended for broad ecosystem support)
+
+The `rdt-mcp` server exposes all RDT functionality as typed [Model Context Protocol](https://modelcontextprotocol.io) tools. Any MCP-compatible client — Claude Desktop, Cursor, Windsurf, VS Code Copilot, Continue — can discover and call them directly without running shell commands.
+
+**Install with MCP support:**
+
+```bash
+pip install "rdt-rambo[mcp]"
+# or
+pipx install "rdt-rambo[mcp]"
+```
+
+**Configure your client** (example for Claude Desktop — `claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "rdt": { "command": "rdt-mcp" }
+  }
+}
+```
+
+The server exposes 7 tools: `rdt_init`, `rdt_add`, `rdt_remove`, `rdt_list`, `rdt_doctor`, `rdt_check`, `rdt_up`. Each tool accepts typed parameters and returns structured JSON — no shell output to parse.
+
+→ **Full MCP documentation:** [`docs/en/mcp-server.md`](./docs/en/mcp-server.md)
+
+---
+
+### Option B — Agentic Skill (Augment / prompt-injection based clients)
+
+For AI assistants that work by injecting instructions into context (such as Augment Code), use the provided skill file:
 
 [**`rdt-skill.md`**](./docs/skills/rdt-skill.md)
 
-> This file contains precise instructions, API rules, and a catalog reference specifically formatted for LLMs. Give your agent access to this file and ask it to "Initialize a Postgres + Redis backend stack using the rules in rdt-skill.md".
+> This file contains precise instructions, API rules, and a catalog reference specifically formatted for LLMs. Point your agent to this file and ask it to "Initialize a Postgres + Redis backend stack using the rules in rdt-skill.md".
+
+---
+
+### Which to use?
+
+| | MCP Server | Skill |
+|---|---|---|
+| Works in Claude Desktop, Cursor, Windsurf | ✅ | ❌ |
+| Works in Augment Code | ✅ | ✅ |
+| Structured JSON responses | ✅ | ❌ |
+| No shell execution needed | ✅ | ❌ |
+| Zero extra dependencies | ❌ | ✅ |
 
 ---
 

--- a/docs/en/mcp-server.md
+++ b/docs/en/mcp-server.md
@@ -1,0 +1,409 @@
+# RDT MCP Server
+
+> **Rambo Docker Tools** — `docker-compose.yml` generator.  
+> The MCP server exposes all RDT functionality as typed [Model Context Protocol](https://modelcontextprotocol.io) tools, enabling native integration with Claude Desktop, Cursor, Windsurf, VS Code Copilot, Continue, and any other MCP-compatible AI client.
+
+---
+
+## Table of Contents
+
+- [Why MCP vs the Skill](#why-mcp-vs-the-skill)
+- [Installation](#installation)
+- [Client Setup](#client-setup)
+  - [Claude Desktop](#claude-desktop)
+  - [Cursor](#cursor)
+  - [Windsurf](#windsurf)
+  - [VS Code + Continue](#vs-code--continue)
+- [Available Tools](#available-tools)
+  - [rdt_init](#rdt_init)
+  - [rdt_add](#rdt_add)
+  - [rdt_remove](#rdt_remove)
+  - [rdt_list](#rdt_list)
+  - [rdt_doctor](#rdt_doctor)
+  - [rdt_check](#rdt_check)
+  - [rdt_up](#rdt_up)
+- [Response Format](#response-format)
+- [Typical Agent Workflow](#typical-agent-workflow)
+
+---
+
+## Why MCP vs the Skill
+
+RDT ships with two integration options for AI agents.
+
+| | MCP Server | Skill (`rdt-skill.md`) |
+|---|---|---|
+| Works in Claude Desktop, Cursor, Windsurf | ✅ | ❌ |
+| Works in Augment Code | ✅ | ✅ |
+| Typed parameters, no shell composition | ✅ | ❌ |
+| Structured JSON responses | ✅ | ❌ |
+| No terminal / process execution needed | ✅ | ❌ |
+| Zero extra dependencies | ❌ | ✅ |
+
+**Use MCP** when you want RDT available across multiple clients without per-client prompt setup.  
+**Use the Skill** when you are working exclusively inside Augment Code and want zero installation overhead.
+
+The two approaches are not mutually exclusive — you can have both configured simultaneously.
+
+---
+
+## Installation
+
+The MCP server is an optional extra. Install it alongside RDT:
+
+```bash
+# pip
+pip install "rdt-rambo[mcp]"
+
+# pipx (recommended for system-wide CLI tools)
+pipx install "rdt-rambo[mcp]"
+
+# from source
+pip install -e ".[mcp]"
+```
+
+After installation, the `rdt-mcp` binary is available on your PATH:
+
+```bash
+rdt-mcp --help
+```
+
+The server communicates over **stdio** (standard input/output) — the client launches the process and exchanges JSON-RPC messages through its stdin/stdout. No port binding or network configuration is required.
+
+---
+
+## Client Setup
+
+### Claude Desktop
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "rdt": {
+      "command": "rdt-mcp"
+    }
+  }
+}
+```
+
+Restart Claude Desktop. The RDT tools will appear in the tools panel (🔧 icon).
+
+---
+
+### Cursor
+
+Create or edit `.cursor/mcp.json` in your project root (project-scoped) or `~/.cursor/mcp.json` (global):
+
+```json
+{
+  "mcpServers": {
+    "rdt": {
+      "command": "rdt-mcp"
+    }
+  }
+}
+```
+
+Reload Cursor. RDT tools are now available to the Cursor AI agent.
+
+---
+
+### Windsurf
+
+Edit `~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "rdt": {
+      "command": "rdt-mcp"
+    }
+  }
+}
+```
+
+---
+
+### VS Code + Continue
+
+Add to your `~/.continue/config.json`:
+
+```json
+{
+  "mcpServers": [
+    {
+      "name": "rdt",
+      "command": "rdt-mcp",
+      "args": []
+    }
+  ]
+}
+```
+
+---
+
+## Available Tools
+
+All tools accept an optional `project_dir` parameter — an absolute path to the working directory. When omitted, the current working directory is used. All file paths (`file`) are resolved relative to `project_dir`.
+
+---
+
+### rdt_init
+
+Initialize a new `docker-compose.yml`, `.env`, and `.env.example` in the project directory.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|:--------:|---------|-------------|
+| `file` | string | no | `docker-compose.yml` | Compose file name or path |
+| `force` | boolean | no | `false` | Overwrite existing files |
+| `project_dir` | string | no | cwd | Absolute path to the project directory |
+
+**Success response:**
+```json
+{
+  "status": "ok",
+  "file": "docker-compose.yml",
+  "created": [
+    "docker-compose.yml",
+    "/absolute/path/.env",
+    "/absolute/path/.env.example"
+  ]
+}
+```
+
+**Error response:**
+
+```json
+{ "status": "error", "message": "File already exists: docker-compose.yml. Use force=True to overwrite." }
+```
+
+---
+
+### rdt_add
+
+Add a service to `docker-compose.yml`. Creates the compose block, writes credentials to `.env` / `.env.example`, generates companion config files (e.g. `nginx/nginx.conf`, `prometheus/prometheus.yml`), and sets up volumes and healthchecks.
+
+Always prefer `rdt_add` over editing the compose file manually.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|:--------:|---------|-------------|
+| `service` | string | **yes** | — | Service name (e.g. `postgres`, `redis`, `nginx-proxy`). Use `rdt_list` to see all options. |
+| `file` | string | no | `docker-compose.yml` | Compose file path |
+| `project_dir` | string | no | cwd | Absolute path to the project directory |
+| `port` | integer | no | preset default | Override the default host port |
+| `volume` | string | no | `<service>_data` | Named volume or bind-mount path (e.g. `./data/pg`) |
+| `depends_on` | string[] | no | `[]` | Services this service depends on |
+| `hardcore` | boolean | no | `false` | Generate strong random passwords instead of placeholder defaults |
+| `no_ports` | boolean | no | `false` | Expose ports only inside the Docker network, not to the host |
+| `network` | string | no | `bridge` | Network type or external network name: `bridge` \| `host` \| `none` \| `<name>` |
+| `container_name` | string | no | service name | Explicit container name |
+| `hc_interval` | string | no | preset default | Healthcheck interval (e.g. `10s`) |
+| `hc_timeout` | string | no | preset default | Healthcheck timeout (e.g. `5s`) |
+| `hc_retries` | integer | no | preset default | Healthcheck retry count |
+| `hc_start_period` | string | no | preset default | Healthcheck start period (e.g. `30s`) |
+| `set_vars` | object | no | `{}` | Override any internal wizard variable (e.g. `{"nginx_upstream": "app:8080"}`) |
+
+**Success response:**
+```json
+{
+  "status": "ok",
+  "service": "postgres",
+  "port": 5432,
+  "env_vars": {
+    "POSTGRES_USER": "postgres",
+    "POSTGRES_PASSWORD": "postgres",
+    "POSTGRES_DB": "postgres"
+  },
+  "artifacts_created": [],
+  "hints": []
+}
+```
+
+**Error response:**
+```json
+{ "status": "error", "message": "Service 'postgres' already exists in docker-compose.yml." }
+```
+
+---
+
+### rdt_remove
+
+Remove a service from `docker-compose.yml`. Optionally cleans up orphaned `.env` variables and companion config files generated for that service.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|:--------:|---------|-------------|
+| `service` | string | **yes** | — | Service name to remove |
+| `file` | string | no | `docker-compose.yml` | Compose file path |
+| `project_dir` | string | no | cwd | Absolute path to the project directory |
+| `clean_env` | boolean | no | `false` | Remove orphaned variables from `.env` and `.env.example` |
+| `clean_artifacts` | boolean | no | `false` | Delete companion config files generated for this service |
+
+**Success response:**
+```json
+{
+  "status": "ok",
+  "removed": "postgres",
+  "removed_volumes": ["postgres_data"],
+  "cleaned_env_vars": ["POSTGRES_USER", "POSTGRES_PASSWORD", "POSTGRES_DB"],
+  "cleaned_files": [],
+  "dependents_warned": ["pgadmin"]
+}
+```
+
+> **Note:** `dependents_warned` lists services that had `depends_on: [<removed service>]`. The removal proceeds, but those services may need to be updated or removed as well.
+
+---
+
+### rdt_list
+
+List all available service presets. Read-only — does not modify anything.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|:--------:|---------|-------------|
+| `category` | string | no | — | Filter by category (e.g. `Relational DB`, `NoSQL / Cache`, `Monitoring`) |
+
+**Response:**
+```json
+{
+  "presets": [
+    {
+      "name": "postgres",
+      "display_name": "PostgreSQL",
+      "category": "Relational DB",
+      "image": "postgres:16-alpine",
+      "default_port": 5432,
+      "container_port": 5432,
+      "has_healthcheck": true
+    }
+  ]
+}
+```
+
+---
+
+### rdt_doctor
+
+Run a full diagnostic check on the project. Verifies Docker availability, Compose v2, YAML validity, `.env` completeness, port conflicts, dangling `depends_on` references, and the presence of companion config files.
+
+**Always call `rdt_doctor` before finishing a task.** It is the single command that validates the entire generated stack.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|:--------:|---------|-------------|
+| `file` | string | no | `docker-compose.yml` | Compose file path |
+| `project_dir` | string | no | cwd | Absolute path to the project directory |
+
+**Response:**
+```json
+{
+  "checks": [
+    { "name": "docker",          "status": "ok",   "message": "Docker 27.3.1",          "details": [] },
+    { "name": "compose",         "status": "ok",   "message": "Docker Compose v2.29.7", "details": [] },
+    { "name": "compose_valid",   "status": "ok",   "message": "Valid",                  "details": [] },
+    { "name": "env_vars",        "status": "ok",   "message": "All variables are set",  "details": [] },
+    { "name": "port_conflicts",  "status": "ok",   "message": "No conflicts",           "details": [] },
+    { "name": "dangling_deps",   "status": "ok",   "message": "No dangling deps",       "details": [] },
+    { "name": "companion_files", "status": "ok",   "message": "All files present",      "details": [] }
+  ],
+  "summary": { "ok": 7, "warn": 0, "error": 0, "skip": 0 }
+}
+```
+
+Check statuses: `ok`, `warn`, `error`, `skip`.
+
+---
+
+### rdt_check
+
+Validate `docker-compose.yml` syntax by running `docker compose config`. Detects YAML errors, unknown keys, and invalid references.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|:--------:|---------|-------------|
+| `file` | string | no | `docker-compose.yml` | Compose file path |
+| `project_dir` | string | no | cwd | Absolute path to the project directory |
+
+**Success response:**
+```json
+{ "valid": true }
+```
+
+**Failure response:**
+```json
+{ "valid": false, "error": "service \"app\": depends_on.postgres: service not found" }
+```
+
+---
+
+### rdt_up
+
+Start the Docker Compose stack via `docker compose up`.
+
+> **Do not call this tool unless the user explicitly asks to start the stack.**
+> The standard agent workflow ends with `rdt_doctor` — the user starts the stack themselves.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|:--------:|---------|-------------|
+| `file` | string | no | `docker-compose.yml` | Compose file path |
+| `project_dir` | string | no | cwd | Absolute path to the project directory |
+| `detach` | boolean | no | `true` | Run containers in the background |
+
+**Response:**
+```json
+{ "command": "docker compose -f docker-compose.yml up -d", "returncode": 0 }
+```
+
+---
+
+## Response Format
+
+All tools return a JSON object. The fields present depend on the tool:
+
+- **`status`** (`"ok"` / `"error"`) — included when the operation mutates state (`rdt_init`, `rdt_add`, `rdt_remove`)
+- **`message`** — human-readable error description, present only when `status` is `"error"`
+- Tool-specific payload fields (see each tool's documentation above)
+
+When `status` is `"error"`, no files have been written. The `message` field contains enough context to understand the failure without inspecting files.
+
+---
+
+## Typical Agent Workflow
+
+```
+1. rdt_list           → discover available services and their exact names
+2. rdt_init           → create docker-compose.yml, .env, .env.example
+3. rdt_add (×N)       → add each required service
+                         link services via depends_on
+                         use no_ports=true for internal-only services
+                         use hardcore=true for production-grade credentials
+4. rdt_doctor         → validate the entire stack (always do this)
+5. rdt_check          → verify YAML syntax (optional, doctor covers this)
+6.  → present results to the user
+     show credentials from env_vars fields
+     instruct the user to run `rdt up` or call rdt_up if asked
+```
+
+### Example: Postgres + pgAdmin
+
+```
+rdt_init()
+rdt_add("postgres", hardcore=True, volume="./data/pg")
+rdt_add("pgadmin", depends_on=["postgres"], no_ports=False)
+rdt_doctor()
+```
+
+### Example: Monitoring stack
+
+```
+rdt_init()
+rdt_add("prometheus")
+rdt_add("grafana", depends_on=["prometheus"])
+rdt_doctor()
+```
+
+### Example: Remove a service cleanly
+
+```
+rdt_remove("postgres", clean_env=True, clean_artifacts=True)
+rdt_doctor()   # confirm remaining stack is still valid
+```

--- a/docs/ru/mcp-server.md
+++ b/docs/ru/mcp-server.md
@@ -1,0 +1,409 @@
+# RDT MCP-сервер
+
+> **Rambo Docker Tools** — генератор `docker-compose.yml`.  
+> MCP-сервер предоставляет всю функциональность RDT в виде типизированных инструментов [Model Context Protocol](https://modelcontextprotocol.io), обеспечивая нативную интеграцию с Claude Desktop, Cursor, Windsurf, VS Code Copilot, Continue и любым другим MCP-совместимым AI-клиентом.
+
+---
+
+## Содержание
+
+- [Зачем MCP, если есть Skill](#зачем-mcp-если-есть-skill)
+- [Установка](#установка)
+- [Настройка клиентов](#настройка-клиентов)
+  - [Claude Desktop](#claude-desktop)
+  - [Cursor](#cursor)
+  - [Windsurf](#windsurf)
+  - [VS Code + Continue](#vs-code--continue)
+- [Доступные инструменты](#доступные-инструменты)
+  - [rdt_init](#rdt_init)
+  - [rdt_add](#rdt_add)
+  - [rdt_remove](#rdt_remove)
+  - [rdt_list](#rdt_list)
+  - [rdt_doctor](#rdt_doctor)
+  - [rdt_check](#rdt_check)
+  - [rdt_up](#rdt_up)
+- [Формат ответов](#формат-ответов)
+- [Типичный сценарий работы агента](#типичный-сценарий-работы-агента)
+
+---
+
+## Зачем MCP, если есть Skill
+
+RDT поставляется с двумя вариантами интеграции для AI-агентов.
+
+| | MCP-сервер | Skill (`rdt-skill.md`) |
+|---|---|---|
+| Работает в Claude Desktop, Cursor, Windsurf | ✅ | ❌ |
+| Работает в Augment Code | ✅ | ✅ |
+| Типизированные параметры, без составления shell-команд | ✅ | ❌ |
+| Структурированные JSON-ответы | ✅ | ❌ |
+| Не требует терминала / запуска процессов | ✅ | ❌ |
+| Нулевые дополнительные зависимости | ❌ | ✅ |
+
+**Используйте MCP**, если хотите, чтобы RDT был доступен в нескольких клиентах без настройки промптов в каждом.  
+**Используйте Skill**, если работаете исключительно в Augment Code и хотите минимальных накладных расходов.
+
+Оба подхода не исключают друг друга — можно настроить их одновременно.
+
+---
+
+## Установка
+
+MCP-сервер — опциональное дополнение. Установите его вместе с RDT:
+
+```bash
+# pip
+pip install "rdt-rambo[mcp]"
+
+# pipx (рекомендуется для системных CLI-инструментов)
+pipx install "rdt-rambo[mcp]"
+
+# из исходников
+pip install -e ".[mcp]"
+```
+
+После установки бинарник `rdt-mcp` доступен в PATH:
+
+```bash
+rdt-mcp --help
+```
+
+Сервер общается по протоколу **stdio** (стандартный ввод/вывод) — клиент запускает процесс и обменивается JSON-RPC сообщениями через его stdin/stdout. Привязка к порту или сетевая конфигурация не требуется.
+
+---
+
+## Настройка клиентов
+
+### Claude Desktop
+
+Отредактируйте `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) или `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "rdt": {
+      "command": "rdt-mcp"
+    }
+  }
+}
+```
+
+Перезапустите Claude Desktop. Инструменты RDT появятся на панели инструментов (иконка 🔧).
+
+---
+
+### Cursor
+
+Создайте или отредактируйте `.cursor/mcp.json` в корне проекта (область видимости — проект) или `~/.cursor/mcp.json` (глобально):
+
+```json
+{
+  "mcpServers": {
+    "rdt": {
+      "command": "rdt-mcp"
+    }
+  }
+}
+```
+
+Перезагрузите Cursor. Инструменты RDT теперь доступны AI-агенту Cursor.
+
+---
+
+### Windsurf
+
+Отредактируйте `~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "rdt": {
+      "command": "rdt-mcp"
+    }
+  }
+}
+```
+
+---
+
+### VS Code + Continue
+
+Добавьте в `~/.continue/config.json`:
+
+```json
+{
+  "mcpServers": [
+    {
+      "name": "rdt",
+      "command": "rdt-mcp",
+      "args": []
+    }
+  ]
+}
+```
+
+---
+
+## Доступные инструменты
+
+Все инструменты принимают необязательный параметр `project_dir` — абсолютный путь к рабочей директории. Если он не указан, используется текущая рабочая директория. Все пути к файлам (`file`) разрешаются относительно `project_dir`.
+
+---
+
+### rdt_init
+
+Инициализировать новые `docker-compose.yml`, `.env` и `.env.example` в директории проекта.
+
+| Параметр | Тип | Обязательный | По умолчанию | Описание |
+|----------|-----|:------------:|--------------|----------|
+| `file` | string | нет | `docker-compose.yml` | Имя или путь к compose-файлу |
+| `force` | boolean | нет | `false` | Перезаписать существующие файлы |
+| `project_dir` | string | нет | cwd | Абсолютный путь к директории проекта |
+
+**Успешный ответ:**
+```json
+{
+  "status": "ok",
+  "file": "docker-compose.yml",
+  "created": [
+    "docker-compose.yml",
+    "/абсолютный/путь/.env",
+    "/абсолютный/путь/.env.example"
+  ]
+}
+```
+
+**Ответ при ошибке:**
+
+```json
+{ "status": "error", "message": "File already exists: docker-compose.yml. Use force=True to overwrite." }
+```
+
+---
+
+### rdt_add
+
+Добавить сервис в `docker-compose.yml`. Создаёт блок compose, записывает учётные данные в `.env` / `.env.example`, генерирует companion-файлы конфигурации (например, `nginx/nginx.conf`, `prometheus/prometheus.yml`), настраивает volumes и healthcheck.
+
+Всегда предпочитайте `rdt_add` ручному редактированию compose-файла.
+
+| Параметр | Тип | Обязательный | По умолчанию | Описание |
+|----------|-----|:------------:|--------------|----------|
+| `service` | string | **да** | — | Имя сервиса (например, `postgres`, `redis`, `nginx-proxy`). Используйте `rdt_list` для просмотра всех вариантов. |
+| `file` | string | нет | `docker-compose.yml` | Путь к compose-файлу |
+| `project_dir` | string | нет | cwd | Абсолютный путь к директории проекта |
+| `port` | integer | нет | порт пресета | Переопределить порт хоста |
+| `volume` | string | нет | `<service>_data` | Имя volume или путь bind-mount (например, `./data/pg`) |
+| `depends_on` | string[] | нет | `[]` | Сервисы, от которых зависит этот сервис |
+| `hardcore` | boolean | нет | `false` | Генерировать надёжные случайные пароли вместо заглушек |
+| `no_ports` | boolean | нет | `false` | Открывать порты только внутри Docker-сети, не на хост |
+| `network` | string | нет | `bridge` | Тип или имя external-сети: `bridge` \| `host` \| `none` \| `<имя>` |
+| `container_name` | string | нет | имя сервиса | Явное имя контейнера |
+| `hc_interval` | string | нет | по пресету | Интервал healthcheck (например, `10s`) |
+| `hc_timeout` | string | нет | по пресету | Таймаут healthcheck (например, `5s`) |
+| `hc_retries` | integer | нет | по пресету | Количество попыток healthcheck |
+| `hc_start_period` | string | нет | по пресету | Начальный период healthcheck (например, `30s`) |
+| `set_vars` | object | нет | `{}` | Переопределить любую внутреннюю переменную мастера (например, `{"nginx_upstream": "app:8080"}`) |
+
+**Успешный ответ:**
+```json
+{
+  "status": "ok",
+  "service": "postgres",
+  "port": 5432,
+  "env_vars": {
+    "POSTGRES_USER": "postgres",
+    "POSTGRES_PASSWORD": "postgres",
+    "POSTGRES_DB": "postgres"
+  },
+  "artifacts_created": [],
+  "hints": []
+}
+```
+
+**Ответ при ошибке:**
+```json
+{ "status": "error", "message": "Service 'postgres' already exists in docker-compose.yml." }
+```
+
+---
+
+### rdt_remove
+
+Удалить сервис из `docker-compose.yml`. Опционально очищает осиротевшие переменные `.env` и companion-файлы конфигурации, сгенерированные для этого сервиса.
+
+| Параметр | Тип | Обязательный | По умолчанию | Описание |
+|----------|-----|:------------:|--------------|----------|
+| `service` | string | **да** | — | Имя сервиса для удаления |
+| `file` | string | нет | `docker-compose.yml` | Путь к compose-файлу |
+| `project_dir` | string | нет | cwd | Абсолютный путь к директории проекта |
+| `clean_env` | boolean | нет | `false` | Удалить осиротевшие переменные из `.env` и `.env.example` |
+| `clean_artifacts` | boolean | нет | `false` | Удалить companion-файлы конфигурации сервиса |
+
+**Успешный ответ:**
+```json
+{
+  "status": "ok",
+  "removed": "postgres",
+  "removed_volumes": ["postgres_data"],
+  "cleaned_env_vars": ["POSTGRES_USER", "POSTGRES_PASSWORD", "POSTGRES_DB"],
+  "cleaned_files": [],
+  "dependents_warned": ["pgadmin"]
+}
+```
+
+> **Примечание:** `dependents_warned` содержит сервисы, у которых был `depends_on: [<удалённый сервис>]`. Удаление всё равно выполняется, но эти сервисы могут требовать обновления или также удаления.
+
+---
+
+### rdt_list
+
+Список всех доступных пресетов сервисов. Только чтение — ничего не изменяет.
+
+| Параметр | Тип | Обязательный | По умолчанию | Описание |
+|----------|-----|:------------:|--------------|----------|
+| `category` | string | нет | — | Фильтр по категории (например, `Relational DB`, `NoSQL / Cache`, `Monitoring`) |
+
+**Ответ:**
+```json
+{
+  "presets": [
+    {
+      "name": "postgres",
+      "display_name": "PostgreSQL",
+      "category": "Relational DB",
+      "image": "postgres:16-alpine",
+      "default_port": 5432,
+      "container_port": 5432,
+      "has_healthcheck": true
+    }
+  ]
+}
+```
+
+---
+
+### rdt_doctor
+
+Запустить полную диагностику проекта. Проверяет доступность Docker, Compose v2, валидность YAML, полноту `.env`, конфликты портов, висячие ссылки в `depends_on` и наличие companion-файлов конфигурации.
+
+**Всегда вызывайте `rdt_doctor` перед завершением задачи.** Это единственная команда, которая валидирует весь сгенерированный стек целиком.
+
+| Параметр | Тип | Обязательный | По умолчанию | Описание |
+|----------|-----|:------------:|--------------|----------|
+| `file` | string | нет | `docker-compose.yml` | Путь к compose-файлу |
+| `project_dir` | string | нет | cwd | Абсолютный путь к директории проекта |
+
+**Ответ:**
+```json
+{
+  "checks": [
+    { "name": "docker",          "status": "ok",   "message": "Docker 27.3.1",                  "details": [] },
+    { "name": "compose",         "status": "ok",   "message": "Docker Compose v2.29.7",         "details": [] },
+    { "name": "compose_valid",   "status": "ok",   "message": "Valid",                          "details": [] },
+    { "name": "env_vars",        "status": "ok",   "message": "All variables are set",          "details": [] },
+    { "name": "port_conflicts",  "status": "ok",   "message": "No conflicts",                   "details": [] },
+    { "name": "dangling_deps",   "status": "ok",   "message": "No dangling deps",               "details": [] },
+    { "name": "companion_files", "status": "ok",   "message": "All files present",              "details": [] }
+  ],
+  "summary": { "ok": 7, "warn": 0, "error": 0, "skip": 0 }
+}
+```
+
+Статусы проверок: `ok`, `warn`, `error`, `skip`.
+
+---
+
+### rdt_check
+
+Проверить синтаксис `docker-compose.yml` через `docker compose config`. Обнаруживает ошибки YAML, неизвестные ключи и неверные ссылки.
+
+| Параметр | Тип | Обязательный | По умолчанию | Описание |
+|----------|-----|:------------:|--------------|----------|
+| `file` | string | нет | `docker-compose.yml` | Путь к compose-файлу |
+| `project_dir` | string | нет | cwd | Абсолютный путь к директории проекта |
+
+**Успешный ответ:**
+```json
+{ "valid": true }
+```
+
+**Ответ при ошибке:**
+```json
+{ "valid": false, "error": "service \"app\": depends_on.postgres: service not found" }
+```
+
+---
+
+### rdt_up
+
+Запустить Docker Compose стек через `docker compose up`.
+
+> **Не вызывайте этот инструмент, если пользователь явно не просит запустить стек.**
+> Стандартный сценарий работы агента заканчивается на `rdt_doctor` — пользователь запускает стек самостоятельно.
+
+| Параметр | Тип | Обязательный | По умолчанию | Описание |
+|----------|-----|:------------:|--------------|----------|
+| `file` | string | нет | `docker-compose.yml` | Путь к compose-файлу |
+| `project_dir` | string | нет | cwd | Абсолютный путь к директории проекта |
+| `detach` | boolean | нет | `true` | Запустить контейнеры в фоновом режиме |
+
+**Ответ:**
+```json
+{ "command": "docker compose -f docker-compose.yml up -d", "returncode": 0 }
+```
+
+---
+
+## Формат ответов
+
+Все инструменты возвращают JSON-объект. Набор полей зависит от инструмента:
+
+- **`status`** (`"ok"` / `"error"`) — присутствует, когда операция изменяет состояние (`rdt_init`, `rdt_add`, `rdt_remove`)
+- **`message`** — человекочитаемое описание ошибки, присутствует только когда `status` равен `"error"`
+- Специфичные для каждого инструмента поля полезной нагрузки (см. документацию каждого инструмента выше)
+
+Когда `status` равен `"error"`, никакие файлы не были записаны. Поле `message` содержит достаточно контекста для понимания сбоя без инспекции файлов.
+
+---
+
+## Типичный сценарий работы агента
+
+```
+1. rdt_list           → узнать доступные сервисы и их точные имена
+2. rdt_init           → создать docker-compose.yml, .env, .env.example
+3. rdt_add (×N)       → добавить каждый нужный сервис
+                         связать сервисы через depends_on
+                         использовать no_ports=true для внутренних сервисов
+                         использовать hardcore=true для production-паролей
+4. rdt_doctor         → валидировать весь стек (обязательно)
+5. rdt_check          → проверить синтаксис YAML (опционально, doctor это покрывает)
+6.  → представить результаты пользователю
+     показать учётные данные из полей env_vars
+     попросить пользователя запустить `rdt up` или вызвать rdt_up если попросят
+```
+
+### Пример: Postgres + pgAdmin
+
+```
+rdt_init()
+rdt_add("postgres", hardcore=True, volume="./data/pg")
+rdt_add("pgadmin", depends_on=["postgres"], no_ports=False)
+rdt_doctor()
+```
+
+### Пример: Стек мониторинга
+
+```
+rdt_init()
+rdt_add("prometheus")
+rdt_add("grafana", depends_on=["prometheus"])
+rdt_doctor()
+```
+
+### Пример: Удаление сервиса с очисткой
+
+```
+rdt_remove("postgres", clean_env=True, clean_artifacts=True)
+rdt_doctor()   # подтвердить что оставшийся стек всё ещё валиден
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rdt-rambo"
-version = "2.0.1"
+version = "2.1.1"
 description = "Rambo Docker Tools — CLI for docker-compose generation"
 readme = "README.md"
 license = "MIT"
@@ -36,6 +36,11 @@ dependencies = [
     "rich>=13.0",
 ]
 
+[project.optional-dependencies]
+mcp = [
+    "mcp[cli]>=1.0",
+]
+
 [project.urls]
 Homepage = "https://github.com/Skr0ls/RDT"
 Repository = "https://github.com/Skr0ls/RDT"
@@ -43,6 +48,7 @@ Repository = "https://github.com/Skr0ls/RDT"
 
 [project.scripts]
 rdt = "rdt.cli:app"
+rdt-mcp = "rdt.mcp_server:main"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/rdt/cli.py
+++ b/rdt/cli.py
@@ -1,10 +1,11 @@
 """
 CLI точка входа для RDT (Rambo Docker Tools).
 Команды: init, add, list, up, check, doctor, lang
+
+Слой ответственности: парсинг аргументов, интерактивный wizard, Rich-вывод.
+Вся бизнес-логика делегируется в rdt.core.
 """
 from __future__ import annotations
-import subprocess
-import sys
 from pathlib import Path
 from typing import Annotated, Any, Optional
 
@@ -15,25 +16,25 @@ from rich.table import Table
 from rich import box
 
 from rdt.presets.catalog import ALL_PRESETS, ServicePreset
-from rdt.strategies.base import NETWORK_NAME
-from rdt.strategies.factory import get_strategy
 from rdt.yaml_manager import (
-    load_compose, save_compose, make_base_compose, inject_service,
-    get_existing_services, get_services_with_healthcheck,
-    get_dependents, remove_service, get_service_named_volumes,
+    load_compose,
+    get_existing_services,
+    get_services_with_healthcheck,
 )
-from rdt.env_manager import (
-    get_env_values, write_env, write_env_example,
-    find_orphaned_vars, remove_vars_from_env_file,
-)
-from rdt.wizard import run_wizard, run_main_menu, ask_service_choice, build_script_answers
-from rdt.artifacts import (
-    ArtifactContext, ArtifactPipeline, ArtifactPlan, ArtifactResult, PreflightIssue,
-    ScaffoldPipeline, ScaffoldPlan, ScaffoldResult,
-)
+from rdt.wizard import run_wizard, run_main_menu, ask_service_choice
 from rdt.i18n import t
 import rdt.i18n as i18n
-from rdt.doctor import run_all_checks, CheckResult
+from rdt.core import (
+    RdtError,
+    init as core_init,
+    add as core_add,
+    add_from_answers,
+    remove as core_remove,
+    list_presets as core_list_presets,
+    doctor as core_doctor,
+    check as core_check,
+    up as core_up,
+)
 
 app = typer.Typer(
     name="rdt",
@@ -46,13 +47,6 @@ COMPOSE_FILE = Path("docker-compose.yml")
 
 
 def _resolve_project_root(file: Path) -> Path:
-    """
-    Единое правило определения project root:
-    - если --file задан с директорией — root = директория compose-файла
-    - иначе root = текущая рабочая директория
-
-    Все выходные файлы (.env, .env.example, artifacts) строятся от этого корня.
-    """
     return file.parent.resolve()
 
 
@@ -139,114 +133,7 @@ def _change_language() -> None:
         console.print(t("lang.changed", lang=selected))
 
 
-def _do_rollback(
-    console: Console,
-    compose_file: Path,
-    compose_was_new: bool,
-    compose_snapshot: str | None,
-    env_file: Path,
-    env_existed_before: bool,
-    env_snapshot: str | None,
-    env_example_file: Path,
-    env_example_existed_before: bool,
-    env_example_snapshot: str | None,
-    scaffold_results: list[ScaffoldResult],
-    artifact_results: list[ArtifactResult],
-) -> None:
-    """Best-effort rollback: восстановить compose/env и удалить созданные файлы/директории."""
-    console.print(t("rollback.header"))
 
-    # 1. Откатить compose файл
-    try:
-        if compose_was_new:
-            if compose_file.exists():
-                compose_file.unlink()
-                console.print(t("rollback.compose_removed", file=str(compose_file)))
-        elif compose_snapshot is not None:
-            compose_file.write_text(compose_snapshot, encoding="utf-8")
-            console.print(t("rollback.compose_restored", file=str(compose_file)))
-    except Exception as exc:
-        console.print(t("rollback.warn", error=str(exc)))
-
-    # 2. Откатить .env
-    try:
-        if not env_existed_before:
-            if env_file.exists():
-                env_file.unlink()
-                console.print(t("rollback.env_removed", file=str(env_file)))
-        elif env_snapshot is not None:
-            env_file.write_text(env_snapshot, encoding="utf-8")
-            console.print(t("rollback.env_restored", file=str(env_file)))
-    except Exception as exc:
-        console.print(t("rollback.warn", error=str(exc)))
-
-    # 3. Откатить .env.example
-    try:
-        if not env_example_existed_before:
-            if env_example_file.exists():
-                env_example_file.unlink()
-                console.print(t("rollback.env_removed", file=str(env_example_file)))
-        elif env_example_snapshot is not None:
-            env_example_file.write_text(env_example_snapshot, encoding="utf-8")
-            console.print(t("rollback.env_restored", file=str(env_example_file)))
-    except Exception as exc:
-        console.print(t("rollback.warn", error=str(exc)))
-
-    # 4. Удалить созданные артефакты
-    for r in artifact_results:
-        if r.status == "created":
-            try:
-                if r.path.exists():
-                    r.path.unlink()
-                    console.print(t("rollback.artifact_removed", path=str(r.path)))
-            except Exception as exc:
-                console.print(t("rollback.warn", error=str(exc)))
-
-    # 5. Удалить созданные scaffold-директории (только пустые)
-    for r in scaffold_results:
-        if r.status == "created":
-            try:
-                if r.path.exists() and r.path.is_dir() and not any(r.path.iterdir()):
-                    r.path.rmdir()
-                    console.print(t("rollback.dir_removed", path=str(r.path)))
-            except Exception as exc:
-                console.print(t("rollback.warn", error=str(exc)))
-
-    console.print(t("rollback.done"))
-
-
-def _print_plan_summary(
-    file: Path,
-    svc_key: str,
-    env_file: Path,
-    env_values: dict,
-    artifact_plans: list[ArtifactPlan],
-    compose_file_existed: bool,
-    scaffold_plans: list[ScaffoldPlan] | None = None,
-) -> None:
-    """Вывести сводку запланированных изменений до их применения."""
-    console.print(t("plan.header"))
-    if not compose_file_existed:
-        console.print(t("plan.compose_create", file=file))
-    else:
-        console.print(t("plan.compose_add_service", name=svc_key, file=file))
-    if env_values:
-        keys = ", ".join(env_values.keys())
-        console.print(t("plan.env_write", file=env_file, keys=keys))
-    for sp in (scaffold_plans or []):
-        path_str = str(sp.target)
-        if sp.action == "create":
-            console.print(t("plan.scaffold_create", path=path_str))
-        elif sp.action == "skip":
-            console.print(t("plan.scaffold_skip", path=path_str))
-    for ap in artifact_plans:
-        path_str = str(ap.target)
-        if ap.action == "create":
-            console.print(t("plan.artifact_create", path=path_str))
-        elif ap.action == "overwrite":
-            console.print(t("plan.artifact_overwrite", path=path_str))
-        elif ap.action == "skip":
-            console.print(t("plan.artifact_skip", path=path_str))
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -257,25 +144,15 @@ def init(
     file: Annotated[Path, typer.Option("--file", "-f", help=t("cmd.init.opt_file"))] = COMPOSE_FILE,
     force: Annotated[bool, typer.Option("--force", help=t("cmd.init.opt_force"))] = False,
 ) -> None:
-    if file.exists() and not force:
-        console.print(t("msg.file_exists", file=file))
+    try:
+        result = core_init(file, force=force)
+    except RdtError as e:
+        console.print(str(e))
         raise typer.Exit(1)
 
-    project_root = _resolve_project_root(file)
-    env_file = project_root / ".env"
-    env_example_file = project_root / ".env.example"
-
-    data = make_base_compose()
-    save_compose(file, data)
-    console.print(t("msg.compose_created", file=file))
-
-    # Инициализировать .env и .env.example если не существуют
-    if not env_file.exists():
-        env_file.touch()
-        console.print(t("msg.env_created", file=env_file))
-    if not env_example_file.exists():
-        env_example_file.touch()
-        console.print(t("msg.env_created", file=env_example_file))
+    console.print(t("msg.compose_created", file=result.file))
+    for path in result.created[1:]:
+        console.print(t("msg.env_created", file=path))
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -306,25 +183,7 @@ def add(
         console.print(t("msg.use_rdt_list"))
         raise typer.Exit(1)
 
-    # Загрузить compose если существует, иначе отложим создание до получения answers
-    if file.exists():
-        data = load_compose(file)
-        existing = get_existing_services(data)
-        svc_with_hc = get_services_with_healthcheck(data)
-    else:
-        data = None
-        existing = []
-        svc_with_hc = set()
-
-    # Проверить что сервис не добавлен дважды (ключ в services = preset.name)
-    svc_key = preset.name
-    if svc_key in existing:
-        console.print(t("msg.file_exists", file=f"{svc_key} in {file}"))
-        raise typer.Exit(1)
-
-    # ── Парсинг --set key=value ──────────────────────────────────────────────
-    # Позволяет переопределить любой ответ мастера без интерактивного режима.
-    # Пример: --set nginx_upstream=app:8080 --set nginx_server_name=example.com
+    # Парсинг --set key=value
     set_overrides: dict[str, str] = {}
     for param in (set_params or []):
         if "=" not in param:
@@ -333,195 +192,67 @@ def add(
         k, v = param.split("=", 1)
         set_overrides[k.strip()] = v.strip()
 
-    # Режим с мастером или без
     has_script_flags = (
         yes or port is not None or volume is not None or depends_on is not None
         or container_name_opt is not None or no_ports or network is not None
         or hc_interval is not None or hc_timeout is not None
         or hc_retries is not None or hc_start_period is not None
     )
-    if has_script_flags:
-        console.print(t("msg.adding_service_script", name=preset.display_name))
-        answers = build_script_answers(
-            preset=preset,
-            port=port,
-            volume=volume,
-            depends_on=depends_on or [],
-            hardcore=hardcore,
-            existing_services=existing,
-            container_name=container_name_opt,
-            no_ports=no_ports,
-            network=network,
-            hc_interval=hc_interval,
-            hc_timeout=hc_timeout,
-            hc_retries=hc_retries,
-            hc_start_period=hc_start_period,
-        )
-    else:
-        answers = run_wizard(preset, existing, hardcore=hardcore, services_with_healthcheck=svc_with_hc)
 
-    # Применяем --set поверх ответов мастера/скрипта
-    if set_overrides:
-        answers.update(set_overrides)
-        if set_overrides:
-            console.print(t("msg.set_overrides_applied", count=len(set_overrides)))
+    try:
+        if has_script_flags:
+            console.print(t("msg.adding_service_script", name=preset.display_name))
+            result = core_add(
+                service=service,
+                file=file,
+                port=port,
+                volume=volume,
+                depends_on=depends_on,
+                hardcore=hardcore,
+                no_ports=no_ports,
+                network=network,
+                container_name=container_name_opt,
+                hc_interval=hc_interval,
+                hc_timeout=hc_timeout,
+                hc_retries=hc_retries,
+                hc_start_period=hc_start_period,
+                set_vars=set_overrides or None,
+            )
+        else:
+            # Wizard mode — интерактивный режим остаётся в CLI
+            if file.exists():
+                data = load_compose(file)
+                existing = get_existing_services(data)
+                svc_with_hc = get_services_with_healthcheck(data)
+            else:
+                existing = []
+                svc_with_hc = set()
+            answers: dict[str, Any] = run_wizard(
+                preset, existing, hardcore=hardcore, services_with_healthcheck=svc_with_hc,
+            )
+            if set_overrides:
+                answers.update(set_overrides)
+                console.print(t("msg.set_overrides_applied", count=len(set_overrides)))
+            answers["services_with_healthcheck"] = svc_with_hc
+            result = add_from_answers(service, answers, file, hardcore=hardcore)
+    except RdtError as e:
+        console.print(str(e))
+        raise typer.Exit(1)
 
-    # Передаём в стратегию информацию о том, у каких сервисов есть healthcheck
-    answers["services_with_healthcheck"] = svc_with_hc
-
-    # ── Единый project root ──────────────────────────────────────────────────
-    # Правило: root = директория compose-файла (работает как для default так и для --file)
+    # ── Presentation ──────────────────────────────────────────────────────────
     project_root = _resolve_project_root(file)
     env_file = project_root / ".env"
-    env_example_file = project_root / ".env.example"
-
-    # ── ФАЗА ПЛАНИРОВАНИЯ (ничего не пишем на диск) ──────────────────────────
-
-    # Подготовить compose-данные в памяти
-    compose_was_new = data is None
-    if compose_was_new:
-        console.print(t("msg.compose_not_found_create", file=file))
-        net_cfg: dict = {
-            "type": answers.get("network_type", "bridge"),
-            "name": answers.get("network_name", NETWORK_NAME),
-        }
-        data = make_base_compose(network_config=net_cfg)
-
-    # Получить значения переменных окружения
-    env_values = get_env_values(preset.default_env, hardcore=hardcore or not answers.get("use_default_creds", True))
-
-    # Применить стратегию (в памяти)
-    strategy = get_strategy(preset, answers)
-    service_def = strategy.build()
-
-    # Вставить сервис в compose (в памяти, без записи на диск)
-    net_cfg = {
-        "type": answers.get("network_type", "bridge"),
-        "name": answers.get("network_name", NETWORK_NAME),
-    }
-    data = inject_service(data, svc_key, service_def, network_config=net_cfg)
-
-    # Построить scaffold-план (директории) без записи на диск
-    scaffold_pipeline: ScaffoldPipeline | None = None
-    scaffold_plans: list[ScaffoldPlan] = []
-    if preset.scaffolds:
-        scaffold_pipeline = ScaffoldPipeline(preset.scaffolds, project_root)
-        scaffold_plans = scaffold_pipeline.plan()
-
-    # Построить артефакт-план без записи на диск
-    pipeline: ArtifactPipeline | None = None
-    artifact_plans: list[ArtifactPlan] = []
-    if preset.artifacts:
-        artifact_ctx = ArtifactContext(
-            service_name=svc_key,
-            answers=answers,
-            env_values=env_values,
-            project_root=project_root,
-            compose_file=file.resolve(),
-            preset=preset,
-            smart_env=answers.get("smart_env", {}),
-            depends_on=answers.get("depends_on", []),
-            parent_service=answers.get("parent_service"),
-            service_def=service_def,
-        )
-        pipeline = ArtifactPipeline(preset.artifacts, artifact_ctx)
-
-        # Preflight-проверка до фактической записи
-        issues = pipeline.preflight()
-        if issues:
-            console.print()
-            console.print(t("artifacts.preflight.header"))
-            for issue in issues:
-                console.print(t("artifacts.preflight.issue", path=issue.artifact_path, reason=issue.reason))
-            raise typer.Exit(1)
-
-        artifact_plans = pipeline.plan()
-
-    # Вывести сводку запланированных изменений
-    _print_plan_summary(
-        file=file,
-        svc_key=svc_key,
-        env_file=env_file,
-        env_values=env_values,
-        artifact_plans=artifact_plans,
-        compose_file_existed=not compose_was_new,
-        scaffold_plans=scaffold_plans,
-    )
-
-    # ── Снимок состояния перед записью (для best-effort rollback) ────────────
-    compose_snapshot: str | None = file.read_text(encoding="utf-8") if file.exists() else None
-    env_existed_before = env_file.exists()
-    env_snapshot: str | None = env_file.read_text(encoding="utf-8") if env_existed_before else None
-    env_example_existed_before = env_example_file.exists()
-    env_example_snapshot: str | None = (
-        env_example_file.read_text(encoding="utf-8") if env_example_existed_before else None
-    )
-
-    # ── ФАЗА ПРИМЕНЕНИЯ (запись на диск) ─────────────────────────────────────
-
-    save_compose(file, data)
-    write_env(env_file, env_values)
-    write_env_example(env_example_file, env_values)
 
     console.print(t("msg.service_added", name=preset.display_name, file=file))
-    if env_values:
+    if result.env_vars:
         console.print(t("msg.env_written", file=env_file))
-
-    scaffold_results: list[ScaffoldResult] = []
-    if scaffold_pipeline is not None:
-        scaffold_results = scaffold_pipeline.apply(scaffold_plans)
-        ScaffoldPipeline.print_results(scaffold_results, console)
-
-        # Scaffold errors теперь фатальны + best-effort rollback
-        if ScaffoldPipeline.has_errors(scaffold_results):
-            console.print(t("scaffold.fatal_error"))
-            _do_rollback(
-                console=console,
-                compose_file=file,
-                compose_was_new=compose_was_new,
-                compose_snapshot=compose_snapshot,
-                env_file=env_file,
-                env_existed_before=env_existed_before,
-                env_snapshot=env_snapshot,
-                env_example_file=env_example_file,
-                env_example_existed_before=env_example_existed_before,
-                env_example_snapshot=env_example_snapshot,
-                scaffold_results=scaffold_results,
-                artifact_results=[],
-            )
-            raise typer.Exit(1)
-
-    if pipeline is not None:
-        artifact_results = pipeline.apply(artifact_plans)
-        ArtifactPipeline.print_results(artifact_results, console)
-
-        # Фатальная ошибка если хотя бы один артефакт не сгенерирован — выполнить rollback
-        if ArtifactPipeline.has_errors(artifact_results):
-            console.print(t("artifacts.fatal_error"))
-            _do_rollback(
-                console=console,
-                compose_file=file,
-                compose_was_new=compose_was_new,
-                compose_snapshot=compose_snapshot,
-                env_file=env_file,
-                env_existed_before=env_existed_before,
-                env_snapshot=env_snapshot,
-                env_example_file=env_example_file,
-                env_example_existed_before=env_example_existed_before,
-                env_example_snapshot=env_example_snapshot,
-                scaffold_results=scaffold_results,
-                artifact_results=artifact_results,
-            )
-            raise typer.Exit(1)
-
-    # Вывести bootstrap-подсказки после успешного применения
-    if preset.bootstrap_hints:
+    for path in result.artifacts_created:
+        console.print(t("plan.artifact_create", path=path))
+    if result.hints:
         console.print()
         console.print(t("bootstrap.header"))
-        for hint in preset.bootstrap_hints:
-            console.print(t("bootstrap.hint", message=hint.message))
-            if hint.command:
-                console.print(t("bootstrap.command", command=hint.command))
+        for hint in result.hints:
+            console.print(t("bootstrap.hint", message=hint))
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -529,9 +260,10 @@ def add(
 # ─────────────────────────────────────────────────────────────────────────────
 @app.command(name="list", help=t("cmd.list.help"))
 def list_presets() -> None:
-    categories: dict[str, list[ServicePreset]] = {}
-    for preset in ALL_PRESETS.values():
-        categories.setdefault(preset.category, []).append(preset)
+    presets = core_list_presets()
+    categories: dict[str, list] = {}
+    for p in presets:
+        categories.setdefault(p.category, []).append(p)
 
     table = Table(title=t("table.title"), box=box.ROUNDED, show_lines=True)
     table.add_column(t("table.col_category"), style="cyan bold", no_wrap=True)
@@ -540,8 +272,8 @@ def list_presets() -> None:
     table.add_column(t("table.col_image"), style="dim")
     table.add_column(t("table.col_port"), style="yellow", justify="right")
 
-    for category, presets in categories.items():
-        for i, p in enumerate(presets):
+    for category, items in categories.items():
+        for i, p in enumerate(items):
             table.add_row(
                 category if i == 0 else "",
                 f"rdt add {p.name}",
@@ -561,17 +293,13 @@ def up(
     file: Annotated[Path, typer.Option("--file", "-f", help=t("cmd.up.opt_file"))] = COMPOSE_FILE,
     detach: Annotated[bool, typer.Option("--detach/--no-detach", "-d", help=t("cmd.up.opt_detach"))] = True,
 ) -> None:
-    if not file.exists():
-        console.print(t("msg.compose_not_found_run", file=file))
+    try:
+        result = core_up(file, detach=detach)
+    except RdtError as e:
+        console.print(str(e))
         raise typer.Exit(1)
-
-    cmd = ["docker", "compose", "-f", str(file), "up"]
-    if detach:
-        cmd.append("-d")
-
-    console.print(t("msg.running_cmd", cmd=" ".join(cmd)))
-    result = subprocess.run(cmd)
-    sys.exit(result.returncode)
+    console.print(t("msg.running_cmd", cmd=result.command))
+    raise typer.Exit(result.returncode)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -582,46 +310,25 @@ def check(
     file: Annotated[Path, typer.Option("--file", "-f", help=t("cmd.check.opt_file"))] = COMPOSE_FILE,
     verbose: Annotated[bool, typer.Option("--verbose", "-v", help=t("cmd.check.opt_verbose"))] = False,
 ) -> None:
-    if not file.exists():
-        console.print(t("msg.compose_not_found_run", file=file))
+    console.print(t("msg.check_running", file=file))
+    try:
+        result = core_check(file)
+    except RdtError as e:
+        console.print(str(e))
         raise typer.Exit(1)
 
-    cmd = ["docker", "compose", "-f", str(file), "config"]
-    console.print(t("msg.check_running", file=file))
-
-    result = subprocess.run(cmd, capture_output=True, text=True)
-
-    if result.returncode == 0:
-        if verbose and result.stdout:
-            console.print(result.stdout.strip())
+    if result.valid:
         console.print(t("msg.check_ok", file=file))
     else:
-        if result.stderr:
-            console.print(result.stderr.strip())
+        if result.error:
+            console.print(result.error)
         console.print(t("msg.check_fail", file=file))
-        raise typer.Exit(result.returncode)
+        raise typer.Exit(1)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
 # rdt remove
 # ─────────────────────────────────────────────────────────────────────────────
-
-def _get_artifact_paths_for_service(service_name: str, project_root: Path) -> list[Path]:
-    """Вернуть список companion-файлов для сервиса, которые существуют на диске.
-
-    Берёт список артефактов из пресета (если он есть) и возвращает
-    только те файлы, что физически присутствуют в project_root.
-    """
-    preset = ALL_PRESETS.get(service_name)
-    if preset is None or not preset.artifacts:
-        return []
-    paths: list[Path] = []
-    for artifact_def in preset.artifacts:
-        candidate = project_root / artifact_def.relative_path
-        if candidate.exists():
-            paths.append(candidate)
-    return paths
-
 
 @app.command(name="remove", help=t("cmd.remove.help"))
 def remove(
@@ -631,14 +338,9 @@ def remove(
     clean_env: Annotated[bool, typer.Option("--clean-env", help=t("cmd.remove.opt_clean_env"))] = False,
     clean_artifacts: Annotated[bool, typer.Option("--clean-artifacts", help=t("cmd.remove.opt_clean_artifacts"))] = False,
 ) -> None:
-    # ── 1. Проверить существование compose-файла ─────────────────────────────
     if not file.exists():
         console.print(t("remove.compose_not_found", file=file))
         raise typer.Exit(1)
-
-    project_root = _resolve_project_root(file)
-    env_file = project_root / ".env"
-    env_example_file = project_root / ".env.example"
 
     data = load_compose(file)
     existing = get_existing_services(data)
@@ -647,9 +349,8 @@ def remove(
         console.print(t("remove.no_services", file=file))
         raise typer.Exit(1)
 
-    # ── 2. Выбор сервиса (интерактивно или аргумент) ─────────────────────────
+    # ── Выбор сервиса (interactive или аргумент) ─────────────────────────────
     if service is None:
-        # Интерактивный выбор
         from rdt.wizard import ask_remove_service_choice
         service = ask_remove_service_choice(existing)
         if not service:
@@ -665,120 +366,48 @@ def remove(
 
     console.print(t("remove.header", service=service))
 
-    # ── 3. Предупреждение о зависимых сервисах ───────────────────────────────
-    dependents = get_dependents(data, service)
-    if dependents:
-        console.print(t("remove.dependents_warn", service=service))
-        for dep in dependents:
-            console.print(t("remove.dependents_entry", dependent=dep))
-        console.print(t("remove.dependents_note"))
-        console.print()
+    # ── Интерактивные вопросы по опциям (если не --yes) ─────────────────────
+    if not yes:
+        from rdt.env_manager import find_orphaned_vars
+        from rdt.core import _get_artifact_paths
+        project_root = _resolve_project_root(file)
 
-    # ── 4. Анализ: orphaned ENV vars ─────────────────────────────────────────
-    orphaned_vars: set[str] = set()
-    if clean_env or not yes:
         orphaned_vars = find_orphaned_vars(data, service)
+        artifact_paths = _get_artifact_paths(service, project_root)
 
-    # ── 5. Анализ: companion файлы ───────────────────────────────────────────
-    artifact_paths: list[Path] = []
-    if clean_artifacts or not yes:
-        artifact_paths = _get_artifact_paths_for_service(service, project_root)
-
-    # ── 6. Интерактивные вопросы (если не --yes) ─────────────────────────────
-    if not yes:
         if orphaned_vars and not clean_env:
-            clean_env = questionary.confirm(
-                t("remove.ask_clean_env"),
-                default=True,
-            ).ask() or False
-
+            clean_env = questionary.confirm(t("remove.ask_clean_env"), default=True).ask() or False
         if artifact_paths and not clean_artifacts:
-            clean_artifacts = questionary.confirm(
-                t("remove.ask_clean_artifacts"),
-                default=False,
-            ).ask() or False
+            clean_artifacts = questionary.confirm(t("remove.ask_clean_artifacts"), default=False).ask() or False
 
-    # ── 7. Показать план ─────────────────────────────────────────────────────
-    console.print(t("remove.plan_header"))
-    console.print(t("remove.plan_service", service=service, file=file))
-
-    # Named volumes (рассчитать предварительно)
-    preview_volumes = _preview_orphaned_volumes(data, service)
-    for vol in preview_volumes:
-        console.print(t("remove.plan_volume", volume=vol))
-
-    if clean_env and orphaned_vars:
-        for var in sorted(orphaned_vars):
-            console.print(t("remove.plan_env_var", var=var, file=env_file))
-    elif not orphaned_vars:
-        console.print(t("remove.plan_env_skip"))
-    else:
-        console.print(t("remove.plan_env_skip"))
-
-    if clean_artifacts and artifact_paths:
-        for p in artifact_paths:
-            console.print(t("remove.plan_artifact", path=str(p)))
-    else:
-        console.print(t("remove.plan_artifact_skip"))
-
-    console.print()
-
-    # ── 8. Финальное подтверждение ───────────────────────────────────────────
-    if not yes:
         confirmed = questionary.confirm(t("remove.confirm"), default=False).ask()
         if not confirmed:
             console.print(t("remove.cancelled"))
             raise typer.Exit(0)
 
-    # ── 9. ПРИМЕНЕНИЕ ────────────────────────────────────────────────────────
+    # ── Применение (делегируем в core) ───────────────────────────────────────
+    try:
+        result = core_remove(service, file, clean_env=clean_env, clean_artifacts=clean_artifacts)
+    except RdtError as e:
+        console.print(str(e))
+        raise typer.Exit(1)
 
-    # Удалить сервис + orphaned named volumes из compose
-    data, removed_volumes = remove_service(data, service)
-    save_compose(file, data)
+    # ── Presentation ──────────────────────────────────────────────────────────
+    project_root = _resolve_project_root(file)
+    env_file = project_root / ".env"
+
     console.print(t("remove.compose_saved", file=file))
-    for vol in removed_volumes:
+    for vol in result.removed_volumes:
         console.print(t("remove.volume_removed", volume=vol))
-
-    # Очистить ENV
-    if clean_env and orphaned_vars:
-        removed_count = remove_vars_from_env_file(env_file, orphaned_vars)
-        remove_vars_from_env_file(env_example_file, orphaned_vars)
-        if removed_count:
-            console.print(t("remove.env_file_cleaned", file=env_file, count=removed_count))
-
-    # Удалить companion-файлы
-    if clean_artifacts and artifact_paths:
-        for p in artifact_paths:
-            try:
-                if p.exists():
-                    if p.is_file():
-                        p.unlink()
-                    else:
-                        import shutil
-                        shutil.rmtree(p)
-                    console.print(t("remove.artifact_removed", path=str(p)))
-                else:
-                    console.print(t("remove.artifact_not_found", path=str(p)))
-            except Exception as exc:
-                console.print(t("remove.artifact_error", path=str(p), error=str(exc)))
-
+    if result.cleaned_env_vars:
+        console.print(t("remove.env_file_cleaned", file=env_file, count=len(result.cleaned_env_vars)))
+    for p in result.cleaned_files:
+        console.print(t("remove.artifact_removed", path=p))
+    if result.dependents_warned:
+        console.print(t("remove.dependents_warn", service=service))
+        for dep in result.dependents_warned:
+            console.print(t("remove.dependents_entry", dependent=dep))
     console.print(t("remove.done", service=service))
-
-
-def _preview_orphaned_volumes(data: Any, service_name: str) -> list[str]:
-    """Список named volumes, которые станут осиротевшими после удаления сервиса."""
-    service_volumes = get_service_named_volumes(data, service_name)
-    still_used: set[str] = set()
-    for svc_name, svc_def in (data.get("services") or {}).items():
-        if svc_name == service_name:
-            continue
-        for vol in (svc_def or {}).get("volumes", []):
-            vol_str = str(vol)
-            if ":" in vol_str:
-                source = vol_str.split(":")[0]
-                if not source.startswith(".") and not source.startswith("/"):
-                    still_used.add(source)
-    return [v for v in service_volumes if v not in still_used]
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -812,41 +441,38 @@ _CHECK_LABEL_KEYS = {
 def doctor(
     file: Annotated[Path, typer.Option("--file", "-f", help=t("cmd.doctor.opt_file"))] = COMPOSE_FILE,
 ) -> None:
-    from rich.table import Table
-    from rich import box as rich_box
-
-    project_root = _resolve_project_root(file)
     console.print(t("doctor.header"))
 
-    results = run_all_checks(file, project_root)
+    try:
+        result = core_doctor(file)
+    except RdtError as e:
+        console.print(str(e))
+        raise typer.Exit(1)
 
-    table = Table(box=rich_box.ROUNDED, show_header=True, show_lines=False, expand=False)
+    table = Table(box=box.ROUNDED, show_header=True, show_lines=False, expand=False)
     table.add_column("", width=3, no_wrap=True)
-    table.add_column(t("doctor.check_docker").split()[0] if False else "Check", style="bold", no_wrap=True)
+    table.add_column("Check", style="bold", no_wrap=True)
     table.add_column("Result")
 
-    for r in results:
-        icon = _STATUS_ICON.get(r.status, "?")
-        style = _STATUS_STYLE.get(r.status, "")
-        label = t(_CHECK_LABEL_KEYS.get(r.name, r.name))
-        table.add_row(icon, label, f"[{style}]{r.message}[/]")
+    for r in result.checks:
+        icon = _STATUS_ICON.get(r["status"], "?")
+        style = _STATUS_STYLE.get(r["status"], "")
+        label = t(_CHECK_LABEL_KEYS.get(r["name"], r["name"]))
+        table.add_row(icon, label, f"[{style}]{r['message']}[/]")
 
     console.print(table)
 
-    # Подробности (details) — отдельно под таблицей
-    for r in results:
-        if r.details:
+    for r in result.checks:
+        if r.get("details"):
             console.print()
-            label = t(_CHECK_LABEL_KEYS.get(r.name, r.name))
-            icon = _STATUS_ICON.get(r.status, "?")
+            label = t(_CHECK_LABEL_KEYS.get(r["name"], r["name"]))
+            icon = _STATUS_ICON.get(r["status"], "?")
             console.print(f"  {icon} [bold]{label}:[/]")
-            for line in r.details:
+            for line in r["details"]:
                 console.print(line)
 
-    # Итоговая строка
-    errors = sum(1 for r in results if r.status == "error")
-    warns  = sum(1 for r in results if r.status == "warn")
-
+    errors = result.summary.get("error", 0)
+    warns  = result.summary.get("warn", 0)
     console.print()
     if errors == 0 and warns == 0:
         console.print(t("doctor.summary_ok"))

--- a/rdt/core.py
+++ b/rdt/core.py
@@ -1,0 +1,551 @@
+"""
+RDT Core — бизнес-логика без CLI-зависимостей (Rich / Typer / questionary).
+
+Используется MCP-сервером и может использоваться любым другим клиентом.
+Все функции принимают типизированные параметры и возвращают dataclass-результаты.
+При ошибках бросают RdtError.
+"""
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from rdt.presets.catalog import ALL_PRESETS
+from rdt.strategies.base import NETWORK_NAME
+from rdt.strategies.factory import get_strategy
+from rdt.yaml_manager import (
+    load_compose, save_compose, make_base_compose, inject_service,
+    get_existing_services, get_services_with_healthcheck,
+    get_dependents, remove_service,
+)
+from rdt.env_manager import (
+    get_env_values, write_env, write_env_example,
+    find_orphaned_vars, remove_vars_from_env_file,
+)
+from rdt.wizard import build_script_answers
+from rdt.artifacts import (
+    ArtifactContext, ArtifactPipeline, ArtifactResult,
+    ScaffoldPipeline, ScaffoldResult,
+)
+from rdt.doctor import run_all_checks
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Исключение
+# ─────────────────────────────────────────────────────────────────────────────
+
+class RdtError(Exception):
+    """Ошибка бизнес-логики RDT."""
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Результирующие типы
+# ─────────────────────────────────────────────────────────────────────────────
+
+@dataclass
+class InitResult:
+    file: str
+    created: list[str]
+
+
+@dataclass
+class AddResult:
+    service: str
+    port: int
+    env_vars: dict[str, str]
+    artifacts_created: list[str]
+    hints: list[str]
+
+
+@dataclass
+class RemoveResult:
+    removed: str
+    removed_volumes: list[str]
+    cleaned_env_vars: list[str]
+    cleaned_files: list[str]
+    dependents_warned: list[str]
+
+
+@dataclass
+class PresetInfo:
+    name: str
+    display_name: str
+    category: str
+    image: str
+    default_port: int
+    container_port: int
+    has_healthcheck: bool
+
+
+@dataclass
+class DoctorResult:
+    checks: list[dict[str, Any]]
+    summary: dict[str, int]
+
+
+@dataclass
+class ComposeCheckResult:
+    valid: bool
+    error: str | None = None
+
+
+@dataclass
+class UpResult:
+    command: str
+    returncode: int
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Вспомогательные функции
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _resolve_root(file: Path) -> Path:
+    """Определить project root по аналогии с CLI."""
+    return file.parent.resolve()
+
+
+def _get_artifact_paths(service_name: str, project_root: Path) -> list[Path]:
+    preset = ALL_PRESETS.get(service_name)
+    if preset is None or not preset.artifacts:
+        return []
+    return [
+        project_root / a.relative_path
+        for a in preset.artifacts
+        if (project_root / a.relative_path).exists()
+    ]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# core_init
+# ─────────────────────────────────────────────────────────────────────────────
+
+def init(file: Path, force: bool = False) -> InitResult:
+    """Создать базовый docker-compose.yml, .env и .env.example."""
+    if file.exists() and not force:
+        raise RdtError(f"File already exists: {file}. Use force=True to overwrite.")
+
+    project_root = _resolve_root(file)
+    env_file = project_root / ".env"
+    env_example = project_root / ".env.example"
+
+    data = make_base_compose()
+    save_compose(file, data)
+
+    created = [str(file)]
+    if not env_file.exists():
+        env_file.touch()
+        created.append(str(env_file))
+    if not env_example.exists():
+        env_example.touch()
+        created.append(str(env_example))
+
+    return InitResult(file=str(file), created=created)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# add / add_from_answers / _apply_add
+# ─────────────────────────────────────────────────────────────────────────────
+
+def add(
+    service: str,
+    file: Path,
+    *,
+    port: int | None = None,
+    volume: str | None = None,
+    depends_on: list[str] | None = None,
+    hardcore: bool = False,
+    no_ports: bool = False,
+    network: str | None = None,
+    container_name: str | None = None,
+    hc_interval: str | None = None,
+    hc_timeout: str | None = None,
+    hc_retries: int | None = None,
+    hc_start_period: str | None = None,
+    set_vars: dict[str, str] | None = None,
+) -> AddResult:
+    """Добавить сервис в docker-compose.yml (script/MCP mode)."""
+    service = service.lower()
+    preset = ALL_PRESETS.get(service)
+    if preset is None:
+        raise RdtError(
+            f"Unknown service: '{service}'. "
+            f"Available: {', '.join(sorted(ALL_PRESETS.keys()))}"
+        )
+
+    if file.exists():
+        data = load_compose(file)
+        existing = get_existing_services(data)
+        svc_with_hc = get_services_with_healthcheck(data)
+    else:
+        existing = []
+        svc_with_hc = set()
+
+    if preset.name in existing:
+        raise RdtError(f"Service '{preset.name}' already exists in {file}.")
+
+    answers = build_script_answers(
+        preset=preset,
+        port=port,
+        volume=volume,
+        depends_on=depends_on or [],
+        hardcore=hardcore,
+        existing_services=existing,
+        container_name=container_name,
+        no_ports=no_ports,
+        network=network,
+        hc_interval=hc_interval,
+        hc_timeout=hc_timeout,
+        hc_retries=hc_retries,
+        hc_start_period=hc_start_period,
+    )
+    if set_vars:
+        answers.update(set_vars)
+    answers["services_with_healthcheck"] = svc_with_hc
+
+    return _apply_add(preset, answers, file, hardcore=hardcore)
+
+
+def add_from_answers(
+    service: str,
+    answers: dict[str, Any],
+    file: Path,
+    hardcore: bool = False,
+) -> AddResult:
+    """Добавить сервис, используя готовый словарь answers (wizard mode в CLI)."""
+    service = service.lower()
+    preset = ALL_PRESETS.get(service)
+    if preset is None:
+        raise RdtError(
+            f"Unknown service: '{service}'. "
+            f"Available: {', '.join(sorted(ALL_PRESETS.keys()))}"
+        )
+
+    if file.exists():
+        existing = get_existing_services(load_compose(file))
+        if preset.name in existing:
+            raise RdtError(f"Service '{preset.name}' already exists in {file}.")
+
+    return _apply_add(preset, answers, file, hardcore=hardcore)
+
+
+def _apply_add(
+    preset: Any,
+    answers: dict[str, Any],
+    file: Path,
+    hardcore: bool,
+) -> AddResult:
+    """Применить answers к compose/env/artifacts — общий apply-путь."""
+    svc_key = preset.name
+    project_root = _resolve_root(file)
+    env_file = project_root / ".env"
+    env_example = project_root / ".env.example"
+
+    # Compose в памяти
+    if file.exists():
+        data = load_compose(file)
+        compose_was_new = False
+    else:
+        net_cfg: dict = {
+            "type": answers.get("network_type", "bridge"),
+            "name": answers.get("network_name", NETWORK_NAME),
+        }
+        data = make_base_compose(network_config=net_cfg)
+        compose_was_new = True
+
+    env_values = get_env_values(
+        preset.default_env,
+        hardcore=hardcore or not answers.get("use_default_creds", True),
+    )
+
+    strategy = get_strategy(preset, answers)
+    service_def = strategy.build()
+
+    net_cfg = {
+        "type": answers.get("network_type", "bridge"),
+        "name": answers.get("network_name", NETWORK_NAME),
+    }
+    data = inject_service(data, svc_key, service_def, network_config=net_cfg)
+
+    # Scaffold plan
+    scaffold_pipeline: ScaffoldPipeline | None = None
+    scaffold_plans = []
+    if preset.scaffolds:
+        scaffold_pipeline = ScaffoldPipeline(preset.scaffolds, project_root)
+        scaffold_plans = scaffold_pipeline.plan()
+
+    # Artifact plan
+    pipeline: ArtifactPipeline | None = None
+    artifact_plans = []
+    if preset.artifacts:
+        artifact_ctx = ArtifactContext(
+            service_name=svc_key,
+            answers=answers,
+            env_values=env_values,
+            project_root=project_root,
+            compose_file=file.resolve(),
+            preset=preset,
+            smart_env=answers.get("smart_env", {}),
+            depends_on=answers.get("depends_on", []),
+            parent_service=answers.get("parent_service"),
+            service_def=service_def,
+        )
+        pipeline = ArtifactPipeline(preset.artifacts, artifact_ctx)
+        issues = pipeline.preflight()
+        if issues:
+            raise RdtError(
+                "Preflight check failed: "
+                + "; ".join(f"{i.artifact_path}: {i.reason}" for i in issues)
+            )
+        artifact_plans = pipeline.plan()
+
+    # Снимки для rollback
+    compose_snapshot: str | None = file.read_text(encoding="utf-8") if file.exists() else None
+    env_existed = env_file.exists()
+    env_snapshot: str | None = env_file.read_text(encoding="utf-8") if env_existed else None
+    env_ex_existed = env_example.exists()
+    env_ex_snapshot: str | None = env_example.read_text(encoding="utf-8") if env_ex_existed else None
+
+    # ── Запись на диск ────────────────────────────────────────────────────────
+    save_compose(file, data)
+    write_env(env_file, env_values)
+    write_env_example(env_example, env_values)
+
+    scaffold_results: list[ScaffoldResult] = []
+    artifact_results: list[ArtifactResult] = []
+
+    if scaffold_pipeline is not None:
+        scaffold_results = scaffold_pipeline.apply(scaffold_plans)
+        if ScaffoldPipeline.has_errors(scaffold_results):
+            _rollback(
+                file, compose_was_new, compose_snapshot,
+                env_file, env_existed, env_snapshot,
+                env_example, env_ex_existed, env_ex_snapshot,
+                scaffold_results, artifact_results,
+            )
+            raise RdtError(f"Scaffold error for '{svc_key}'. Changes rolled back.")
+
+    if pipeline is not None:
+        artifact_results = pipeline.apply(artifact_plans)
+        if ArtifactPipeline.has_errors(artifact_results):
+            _rollback(
+                file, compose_was_new, compose_snapshot,
+                env_file, env_existed, env_snapshot,
+                env_example, env_ex_existed, env_ex_snapshot,
+                scaffold_results, artifact_results,
+            )
+            raise RdtError(f"Artifact error for '{svc_key}'. Changes rolled back.")
+
+    return AddResult(
+        service=svc_key,
+        port=answers.get("port", preset.default_port),
+        env_vars=env_values,
+        artifacts_created=[str(r.path) for r in artifact_results if r.status == "created"],
+        hints=[h.message for h in preset.bootstrap_hints],
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _rollback (внутренний)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _rollback(
+    compose_file: Path,
+    compose_was_new: bool,
+    compose_snapshot: str | None,
+    env_file: Path,
+    env_existed: bool,
+    env_snapshot: str | None,
+    env_example: Path,
+    env_ex_existed: bool,
+    env_ex_snapshot: str | None,
+    scaffold_results: list[ScaffoldResult],
+    artifact_results: list[ArtifactResult],
+) -> None:
+    """Best-effort rollback при ошибке применения."""
+    try:
+        if compose_was_new:
+            if compose_file.exists():
+                compose_file.unlink()
+        elif compose_snapshot is not None:
+            compose_file.write_text(compose_snapshot, encoding="utf-8")
+    except Exception:
+        pass
+
+    for path, existed, snapshot in [
+        (env_file, env_existed, env_snapshot),
+        (env_example, env_ex_existed, env_ex_snapshot),
+    ]:
+        try:
+            if not existed:
+                if path.exists():
+                    path.unlink()
+            elif snapshot is not None:
+                path.write_text(snapshot, encoding="utf-8")
+        except Exception:
+            pass
+
+    for r in artifact_results:
+        if r.status == "created":
+            try:
+                if r.path.exists():
+                    r.path.unlink()
+            except Exception:
+                pass
+
+    for r in scaffold_results:
+        if r.status == "created":
+            try:
+                if r.path.exists() and r.path.is_dir() and not any(r.path.iterdir()):
+                    r.path.rmdir()
+            except Exception:
+                pass
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# core_remove
+# ─────────────────────────────────────────────────────────────────────────────
+
+def remove(
+    service: str,
+    file: Path,
+    *,
+    clean_env: bool = False,
+    clean_artifacts: bool = False,
+) -> RemoveResult:
+    """Удалить сервис из docker-compose.yml."""
+    if not file.exists():
+        raise RdtError(f"Compose file not found: {file}")
+
+    project_root = _resolve_root(file)
+    env_file = project_root / ".env"
+    env_example = project_root / ".env.example"
+
+    data = load_compose(file)
+    existing = get_existing_services(data)
+    service = service.lower()
+
+    if service not in existing:
+        raise RdtError(
+            f"Service '{service}' not found in {file}. "
+            f"Available: {', '.join(existing)}"
+        )
+
+    dependents = get_dependents(data, service)
+    orphaned_vars = find_orphaned_vars(data, service) if clean_env else set()
+    artifact_paths = _get_artifact_paths(service, project_root) if clean_artifacts else []
+
+    data, removed_volumes = remove_service(data, service)
+    save_compose(file, data)
+
+    cleaned_vars: list[str] = []
+    if clean_env and orphaned_vars:
+        count = remove_vars_from_env_file(env_file, orphaned_vars)
+        remove_vars_from_env_file(env_example, orphaned_vars)
+        cleaned_vars = sorted(orphaned_vars) if count else []
+
+    cleaned_files: list[str] = []
+    if clean_artifacts and artifact_paths:
+        import shutil
+        for p in artifact_paths:
+            try:
+                if p.exists():
+                    if p.is_file():
+                        p.unlink()
+                    else:
+                        shutil.rmtree(p)
+                    cleaned_files.append(str(p))
+            except Exception:
+                pass
+
+    return RemoveResult(
+        removed=service,
+        removed_volumes=list(removed_volumes),
+        cleaned_env_vars=cleaned_vars,
+        cleaned_files=cleaned_files,
+        dependents_warned=dependents,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# core_list
+# ─────────────────────────────────────────────────────────────────────────────
+
+def list_presets(category: str | None = None) -> list[PresetInfo]:
+    """Вернуть список доступных пресетов."""
+    result = []
+    for preset in ALL_PRESETS.values():
+        if category and preset.category.lower() != category.lower():
+            continue
+        result.append(PresetInfo(
+            name=preset.name,
+            display_name=preset.display_name,
+            category=preset.category,
+            image=preset.image,
+            default_port=preset.default_port,
+            container_port=preset.container_port,
+            has_healthcheck=preset.healthcheck is not None,
+        ))
+    return result
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# core_doctor
+# ─────────────────────────────────────────────────────────────────────────────
+
+def doctor(file: Path) -> DoctorResult:
+    """Запустить полную диагностику проекта."""
+    project_root = _resolve_root(file)
+    results = run_all_checks(file, project_root)
+
+    checks = [
+        {
+            "name": r.name,
+            "status": r.status,
+            "message": r.message,
+            "details": r.details,
+        }
+        for r in results
+    ]
+    summary = {
+        "ok":    sum(1 for r in results if r.status == "ok"),
+        "warn":  sum(1 for r in results if r.status == "warn"),
+        "error": sum(1 for r in results if r.status == "error"),
+        "skip":  sum(1 for r in results if r.status == "skip"),
+    }
+    return DoctorResult(checks=checks, summary=summary)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# core_check
+# ─────────────────────────────────────────────────────────────────────────────
+
+def check(file: Path) -> ComposeCheckResult:
+    """Проверить валидность docker-compose.yml через docker compose config."""
+    if not file.exists():
+        raise RdtError(f"Compose file not found: {file}")
+
+    result = subprocess.run(
+        ["docker", "compose", "-f", str(file), "config"],
+        capture_output=True, text=True,
+    )
+    if result.returncode == 0:
+        return ComposeCheckResult(valid=True)
+    return ComposeCheckResult(valid=False, error=result.stderr.strip() or result.stdout.strip())
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# core_up
+# ─────────────────────────────────────────────────────────────────────────────
+
+def up(file: Path, detach: bool = True) -> UpResult:
+    """Запустить docker compose up."""
+    if not file.exists():
+        raise RdtError(f"Compose file not found: {file}")
+
+    cmd = ["docker", "compose", "-f", str(file), "up"]
+    if detach:
+        cmd.append("-d")
+
+    result = subprocess.run(cmd)
+    return UpResult(command=" ".join(cmd), returncode=result.returncode)

--- a/rdt/mcp_server.py
+++ b/rdt/mcp_server.py
@@ -1,0 +1,291 @@
+"""
+RDT MCP Server — Model Context Protocol сервер для Rambo Docker Tools.
+
+Транспорт: stdio (стандартный для MCP).
+Запуск: rdt-mcp  (entry point определён в pyproject.toml)
+
+Инструменты:
+  rdt_init    — инициализировать docker-compose.yml + .env
+  rdt_add     — добавить сервис в стек
+  rdt_remove  — удалить сервис из стека
+  rdt_list    — список доступных пресетов
+  rdt_doctor  — полная диагностика проекта
+  rdt_check   — валидация YAML через docker compose config
+  rdt_up      — запустить docker compose up
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from rdt.core import (
+    RdtError,
+    add,
+    check,
+    doctor,
+    init,
+    list_presets,
+    remove,
+    up,
+)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Экземпляр сервера
+# ─────────────────────────────────────────────────────────────────────────────
+
+mcp = FastMCP(
+    "rdt",
+    instructions=(
+        "RDT (Rambo Docker Tools) — генератор production-ready docker-compose стеков. "
+        "Используй rdt_list чтобы узнать доступные сервисы, rdt_init для инициализации проекта, "
+        "rdt_add для добавления сервисов, rdt_doctor для диагностики перед запуском. "
+        "Все инструменты принимают параметр project_dir (абсолютный путь к рабочей директории). "
+        "Если project_dir не задан — используется текущая рабочая директория."
+    ),
+)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Вспомогательная функция
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _resolve_file(project_dir: str | None, file: str) -> Path:
+    """Разрешить путь к compose-файлу с учётом project_dir."""
+    base = Path(project_dir) if project_dir else Path.cwd()
+    p = Path(file)
+    return base / p if not p.is_absolute() else p
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Инструменты
+# ─────────────────────────────────────────────────────────────────────────────
+
+@mcp.tool()
+def rdt_init(
+    file: str = "docker-compose.yml",
+    force: bool = False,
+    project_dir: str | None = None,
+) -> dict[str, Any]:
+    """
+    Initialize a new docker-compose.yml, .env and .env.example in the project directory.
+
+    Args:
+        file: Compose file name or path (default: docker-compose.yml).
+        force: Overwrite existing files if True.
+        project_dir: Absolute path to the project directory (default: cwd).
+    """
+    try:
+        result = init(_resolve_file(project_dir, file), force=force)
+        return {"status": "ok", "file": result.file, "created": result.created}
+    except RdtError as e:
+        return {"status": "error", "message": str(e)}
+
+
+@mcp.tool()
+def rdt_add(
+    service: str,
+    file: str = "docker-compose.yml",
+    project_dir: str | None = None,
+    port: int | None = None,
+    volume: str | None = None,
+    depends_on: list[str] | None = None,
+    hardcore: bool = False,
+    no_ports: bool = False,
+    network: str | None = None,
+    container_name: str | None = None,
+    hc_interval: str | None = None,
+    hc_timeout: str | None = None,
+    hc_retries: int | None = None,
+    hc_start_period: str | None = None,
+    set_vars: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """
+    Add a service to docker-compose.yml. Always prefer this over editing the file manually.
+
+    Args:
+        service: Service name (e.g. postgres, redis, nginx-proxy). Use rdt_list to see all options.
+        file: Compose file path (default: docker-compose.yml).
+        project_dir: Absolute path to the project directory (default: cwd).
+        port: Override the default host port.
+        volume: Named volume or bind-mount path (e.g. ./data/pg).
+        depends_on: List of service names this service depends on.
+        hardcore: Generate strong random passwords instead of defaults.
+        no_ports: Expose ports only within the Docker network (not to the host).
+        network: Network type or external network name (bridge|host|none|<name>).
+        container_name: Explicit container name.
+        hc_interval: Healthcheck interval (e.g. 10s).
+        hc_timeout: Healthcheck timeout (e.g. 5s).
+        hc_retries: Healthcheck retries count.
+        hc_start_period: Healthcheck start period (e.g. 30s).
+        set_vars: Override any internal wizard variable (e.g. {"nginx_upstream": "app:8080"}).
+    """
+    try:
+        result = add(
+            service=service,
+            file=_resolve_file(project_dir, file),
+            port=port,
+            volume=volume,
+            depends_on=depends_on,
+            hardcore=hardcore,
+            no_ports=no_ports,
+            network=network,
+            container_name=container_name,
+            hc_interval=hc_interval,
+            hc_timeout=hc_timeout,
+            hc_retries=hc_retries,
+            hc_start_period=hc_start_period,
+            set_vars=set_vars,
+        )
+        return {
+            "status": "ok",
+            "service": result.service,
+            "port": result.port,
+            "env_vars": result.env_vars,
+            "artifacts_created": result.artifacts_created,
+            "hints": result.hints,
+        }
+    except RdtError as e:
+        return {"status": "error", "message": str(e)}
+
+
+@mcp.tool()
+def rdt_remove(
+    service: str,
+    file: str = "docker-compose.yml",
+    project_dir: str | None = None,
+    clean_env: bool = False,
+    clean_artifacts: bool = False,
+) -> dict[str, Any]:
+    """
+    Remove a service from docker-compose.yml.
+
+    Args:
+        service: Service name to remove.
+        file: Compose file path (default: docker-compose.yml).
+        project_dir: Absolute path to the project directory (default: cwd).
+        clean_env: Remove orphaned variables from .env file.
+        clean_artifacts: Delete companion config files generated for this service.
+    """
+    try:
+        result = remove(
+            service=service,
+            file=_resolve_file(project_dir, file),
+            clean_env=clean_env,
+            clean_artifacts=clean_artifacts,
+        )
+        return {
+            "status": "ok",
+            "removed": result.removed,
+            "removed_volumes": result.removed_volumes,
+            "cleaned_env_vars": result.cleaned_env_vars,
+            "cleaned_files": result.cleaned_files,
+            "dependents_warned": result.dependents_warned,
+        }
+    except RdtError as e:
+        return {"status": "error", "message": str(e)}
+
+
+@mcp.tool()
+def rdt_list(category: str | None = None) -> dict[str, Any]:
+    """
+    List all available service presets.
+
+    Args:
+        category: Optional filter by category name
+                  (e.g. "Relational DB", "NoSQL / Cache", "Monitoring").
+    """
+    presets = list_presets(category=category)
+    return {
+        "presets": [
+            {
+                "name": p.name,
+                "display_name": p.display_name,
+                "category": p.category,
+                "image": p.image,
+                "default_port": p.default_port,
+                "container_port": p.container_port,
+                "has_healthcheck": p.has_healthcheck,
+            }
+            for p in presets
+        ]
+    }
+
+
+@mcp.tool()
+def rdt_doctor(
+    file: str = "docker-compose.yml",
+    project_dir: str | None = None,
+) -> dict[str, Any]:
+    """
+    Run a full diagnostic check on the project.
+
+    Checks: Docker availability, Compose v2, YAML validity, .env completeness,
+    port conflicts, dangling depends_on, missing companion files.
+    Always run this before finishing a task.
+
+    Args:
+        file: Compose file path (default: docker-compose.yml).
+        project_dir: Absolute path to the project directory (default: cwd).
+    """
+    try:
+        result = doctor(_resolve_file(project_dir, file))
+        return {"checks": result.checks, "summary": result.summary}
+    except RdtError as e:
+        return {"status": "error", "message": str(e)}
+
+
+@mcp.tool()
+def rdt_check(
+    file: str = "docker-compose.yml",
+    project_dir: str | None = None,
+) -> dict[str, Any]:
+    """
+    Validate docker-compose.yml syntax via `docker compose config`.
+
+    Args:
+        file: Compose file path (default: docker-compose.yml).
+        project_dir: Absolute path to the project directory (default: cwd).
+    """
+    try:
+        result = check(_resolve_file(project_dir, file))
+        if result.valid:
+            return {"valid": True}
+        return {"valid": False, "error": result.error}
+    except RdtError as e:
+        return {"status": "error", "message": str(e)}
+
+
+@mcp.tool()
+def rdt_up(
+    file: str = "docker-compose.yml",
+    project_dir: str | None = None,
+    detach: bool = True,
+) -> dict[str, Any]:
+    """
+    Start the Docker Compose stack.
+    Do NOT call this unless the user explicitly asks to start the stack.
+
+    Args:
+        file: Compose file path (default: docker-compose.yml).
+        project_dir: Absolute path to the project directory (default: cwd).
+        detach: Run containers in the background (default: True).
+    """
+    try:
+        result = up(_resolve_file(project_dir, file), detach=detach)
+        return {"command": result.command, "returncode": result.returncode}
+    except RdtError as e:
+        return {"status": "error", "message": str(e)}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Entry point
+# ─────────────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Bump version to 2.1.1
- Add optional `mcp` dependency group with `mcp[cli]>=1.0`
- Register `rdt-mcp` entry point for MCP server
- Document MCP server installation and configuration in README
- Add comparison table between MCP server and skill-based integration
- Provide Claude Desktop config example
- Clarify that MCP server exposes 7 typed tools with structured JSON responses
- Recommend MCP server for broad ecosystem support (Claude Desktop, Cursor, Windsurf, VS Code Copilot)
- Keep existing skill documentation for prompt-injection based clients like Augment Code