### PR TITLE
fix: enforce inline flow style for `healthcheck.test` in Docker Compose

### DIFF
--- a/rdt/yaml_manager.py
+++ b/rdt/yaml_manager.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from ruamel.yaml import YAML
-from ruamel.yaml.comments import CommentedMap
+from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
 from rdt.strategies.base import NETWORK_NAME
 
@@ -44,6 +44,7 @@ def save_compose(path: Path, data: CommentedMap) -> None:
     import io
     # Гарантировать существование родительской директории (для --file infra/docker-compose.yml)
     path.parent.mkdir(parents=True, exist_ok=True)
+    _normalize_healthcheck_test_flow_style(data)
     y = _make_yaml()
     buf = io.StringIO()
     y.dump(data, buf)
@@ -212,14 +213,40 @@ def get_services_with_healthcheck(data: CommentedMap) -> set[str]:
     return result
 
 
-def _dict_to_commented(d: Any) -> Any:
-    """Рекурсивно конвертировать dict → CommentedMap."""
+def _normalize_healthcheck_test_flow_style(d: Any, path: tuple[str, ...] = ()) -> Any:
+    """Принудительно записывать все healthcheck.test списки в inline (flow) стиле."""
+    if isinstance(d, dict):
+        for k, v in list(d.items()):
+            child_path = path + (str(k),)
+            if len(child_path) >= 2 and child_path[-2:] == ("healthcheck", "test") and isinstance(v, list):
+                seq = v if isinstance(v, CommentedSeq) else CommentedSeq(v)
+                seq.fa.set_flow_style()
+                d[k] = seq
+            else:
+                d[k] = _normalize_healthcheck_test_flow_style(v, child_path)
+        return d
+    if isinstance(d, list):
+        for idx, item in enumerate(d):
+            d[idx] = _normalize_healthcheck_test_flow_style(item, path)
+        return d
+    return d
+
+
+def _dict_to_commented(d: Any, path: tuple[str, ...] = ()) -> Any:
+    """Рекурсивно конвертировать dict → CommentedMap, list → CommentedSeq.
+
+    Списки healthcheck.test сериализуются в inline (flow) стиле,
+    т.к. Docker Compose ожидает test: ["CMD-SHELL", "..."] или ["CMD", "..."].
+    """
     if isinstance(d, dict):
         cm = CommentedMap()
         for k, v in d.items():
-            cm[k] = _dict_to_commented(v)
+            cm[k] = _dict_to_commented(v, path + (k,))
         return cm
     if isinstance(d, list):
-        return [_dict_to_commented(i) for i in d]
+        seq = CommentedSeq([_dict_to_commented(i, path) for i in d])
+        if len(path) >= 2 and path[-2:] == ("healthcheck", "test"):
+            seq.fa.set_flow_style()
+        return seq
     return d
 

--- a/tests/test_artifact_pipeline.py
+++ b/tests/test_artifact_pipeline.py
@@ -1675,3 +1675,111 @@ def test_traefik_scaffold_creates_dirs(tmp_path: Path) -> None:
     assert all(r.status == "created" for r in results)
     assert (tmp_path / "traefik").is_dir()
     assert (tmp_path / "traefik" / "dynamic").is_dir()
+
+
+# ---------------------------------------------------------------------------
+# YAML manager — healthcheck inline flow style
+# ---------------------------------------------------------------------------
+
+def test_dict_to_commented_healthcheck_test_flow_style() -> None:
+    """healthcheck.test сериализуется в inline (flow) стиле."""
+    from rdt.yaml_manager import _dict_to_commented
+    from ruamel.yaml.comments import CommentedSeq
+
+    d = {
+        "healthcheck": {
+            "test": ["CMD-SHELL", "pg_isready || exit 1"],
+            "interval": "10s",
+        },
+        "ports": ["5432:5432"],
+    }
+    cm = _dict_to_commented(d)
+
+    test_seq = cm["healthcheck"]["test"]
+    assert isinstance(test_seq, CommentedSeq)
+    assert test_seq.fa.flow_style() is True
+
+    ports_seq = cm["ports"]
+    assert isinstance(ports_seq, CommentedSeq)
+    assert ports_seq.fa.flow_style() is not True
+
+
+def test_save_compose_healthcheck_test_inline(tmp_path: Path) -> None:
+    """save_compose записывает healthcheck.test как inline-массив."""
+    from rdt.yaml_manager import save_compose, make_base_compose, inject_service
+
+    data = make_base_compose()
+    service_def = {
+        "image": "postgres:16",
+        "healthcheck": {
+            "test": ["CMD-SHELL", "pg_isready -U postgres || exit 1"],
+            "interval": "10s",
+            "timeout": "5s",
+            "retries": 3,
+        },
+        "ports": ["5432:5432"],
+        "volumes": ["pg_data:/var/lib/postgresql/data"],
+        "networks": ["rambo-net"],
+    }
+    inject_service(data, "db", service_def)
+
+    compose_file = tmp_path / "docker-compose.yml"
+    save_compose(compose_file, data)
+    content = compose_file.read_text(encoding="utf-8")
+
+    assert "test: [CMD-SHELL, pg_isready -U postgres || exit 1]" in content
+    assert "ports:\n    - " in content  # block-style под services.db
+    assert "volumes:\n    - pg_data:/var/lib/postgresql/data" in content
+    assert "networks:\n    - rambo-net" in content
+
+
+def test_save_compose_normalizes_existing_healthcheck_test(tmp_path: Path) -> None:
+    """save_compose нормализует уже загруженные block-style healthcheck.test."""
+    from rdt.yaml_manager import save_compose, load_compose
+
+    compose_file = tmp_path / "docker-compose.yml"
+    compose_file.write_text(
+        """
+services:
+  db:
+    image: postgres:16
+    healthcheck:
+      test:
+      - CMD-SHELL
+      - pg_isready -U postgres || exit 1
+      interval: 10s
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    data = load_compose(compose_file)
+    save_compose(compose_file, data)
+    content = compose_file.read_text(encoding="utf-8")
+
+    assert "test: [CMD-SHELL, pg_isready -U postgres || exit 1]" in content
+    assert "test:\n" not in content
+
+
+def test_save_compose_traefik_healthcheck_inline(tmp_path: Path) -> None:
+    """TraefikStrategy + save_compose даёт inline healthcheck.test."""
+    from rdt.strategies.traefik import TraefikStrategy
+    from rdt.presets.catalog import TRAEFIK
+    from rdt.yaml_manager import save_compose, make_base_compose, inject_service
+
+    strategy = TraefikStrategy(
+        TRAEFIK,
+        {
+            "port": 80,
+            "network_name": "rambo-net",
+            "traefik_config_dir": "./traefik",
+        },
+    )
+    svc = strategy.build()
+    data = make_base_compose()
+    inject_service(data, "traefik", svc)
+
+    compose_file = tmp_path / "docker-compose.yml"
+    save_compose(compose_file, data)
+    content = compose_file.read_text(encoding="utf-8")
+
+    assert "test: [CMD-SHELL, wget -qO- http://localhost:8080/ping || exit 1]" in content


### PR DESCRIPTION
- Ensure `healthcheck.test` lists are serialized in inline (flow) style
- Add `_normalize_healthcheck_test_flow_style` function for consistent formatting
- Update `_dict_to_commented` to handle `CommentedSeq` conversion
- Add unit tests to verify correct serialization behavior
- Guarantee compatibility with Docker Compose requirements