### PR TITLE
refactor: standardize codebase to english language

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing
+
+Thank you for helping improve RDT.
+
+## Language for Code and Internal Documentation
+
+English is the default language for contributor-facing and agent-facing project
+content, including:
+
+- source-code comments
+- docstrings
+- inline developer notes
+- MCP/server instructions and other AI-agent-facing prompts
+- tests and other internal developer documentation
+
+Localized user-facing resources should remain in their dedicated locations, such
+as `rdt/locales/ru.json` or `docs/ru/`. Avoid mixing translated UI/docs content
+into source-code comments or internal implementation notes.

--- a/docs/en/scripting.md
+++ b/docs/en/scripting.md
@@ -330,7 +330,7 @@ RDT_LANG=ru rdt add postgres --yes
 | Code | Language |
 |------|----------|
 | `en` | English |
-| `ru` | Русский |
+| `ru` | Russian |
 
 ---
 

--- a/rdt/artifacts.py
+++ b/rdt/artifacts.py
@@ -1,8 +1,8 @@
 """
-Подсистема companion-артефактов RDT.
+RDT companion artifact subsystem.
 
-Позволяет сервисам генерировать дополнительные файлы конфигурации
-(nginx.conf, logstash.conf, prometheus.yml и т.д.) вместе с compose-блоком.
+Allows services to generate additional configuration files
+(nginx.conf, logstash.conf, prometheus.yml, etc.) together with the compose block.
 """
 from __future__ import annotations
 
@@ -17,72 +17,72 @@ from rdt.i18n import t
 
 
 # ---------------------------------------------------------------------------
-# Политика перезаписи
+# Overwrite policy
 # ---------------------------------------------------------------------------
 
 class OverwritePolicy(str, Enum):
-    SKIP = "skip"                       # не перезаписывать если файл уже существует
-    OVERWRITE = "overwrite"             # всегда перезаписывать
-    ERROR_IF_EXISTS = "error_if_exists" # вернуть ошибку если файл уже существует
+    SKIP = "skip"                       # Do not overwrite when the file already exists.
+    OVERWRITE = "overwrite"             # Always overwrite.
+    ERROR_IF_EXISTS = "error_if_exists" # Return an error when the file already exists.
 
 
 # ---------------------------------------------------------------------------
-# Тип источника артефакта
+# Artifact source type
 # ---------------------------------------------------------------------------
 
 class ArtifactSourceType(str, Enum):
-    TEMPLATE = "template"  # Jinja2-шаблон из templates/artifacts/
-    STATIC = "static"      # Статический текст, встроенный в ArtifactDef
-    PYTHON = "python"      # Python-рендерер: (context: ArtifactContext) -> str
+    TEMPLATE = "template"  # Jinja2 template from templates/artifacts/.
+    STATIC = "static"      # Static text embedded in ArtifactDef.
+    PYTHON = "python"      # Python renderer: (context: ArtifactContext) -> str.
 
 
 # ---------------------------------------------------------------------------
-# Богатый контекст генерации артефактов
+# Rich artifact-generation context
 # ---------------------------------------------------------------------------
 
 @dataclass
 class ArtifactContext:
     """
-    Полный контекст для генерации companion-артефактов сервиса.
+    Full context for generating service companion artifacts.
 
-    Передаётся в ArtifactPipeline вместо сырого dict answers.
-    Доступен в Jinja2-шаблонах и Python-рендерерах.
+    Passed to ArtifactPipeline instead of a raw answers dict.
+    Available in Jinja2 templates and Python renderers.
     """
 
     service_name: str
-    """Имя сервиса (ключ в docker-compose, например 'nginx-proxy')."""
+    """Service name (docker-compose key, for example 'nginx-proxy')."""
 
     answers: dict[str, Any]
-    """Ответы мастера или скрипт-режима."""
+    """Wizard or script-mode answers."""
 
     env_values: dict[str, str]
-    """Значения переменных окружения, записываемых в .env."""
+    """Environment variable values written to .env."""
 
     project_root: Path
-    """Корень проекта — от него строятся все пути артефактов."""
+    """Project root used as the base for all artifact paths."""
 
     compose_file: Path
-    """Абсолютный путь к docker-compose.yml."""
+    """Absolute path to docker-compose.yml."""
 
     preset: Any = None
-    """ServicePreset (Any — чтобы избежать circular import из presets/catalog.py)."""
+    """ServicePreset (Any avoids a circular import from presets/catalog.py)."""
 
     smart_env: dict[str, Any] = field(default_factory=dict)
-    """Переменные окружения, установленные Smart Mapping (подмножество answers['smart_env'])."""
+    """Environment variables set by Smart Mapping (subset of answers['smart_env'])."""
 
     depends_on: list[str] = field(default_factory=list)
-    """Зависимости сервиса, установленные Smart Mapping (подмножество answers['depends_on'])."""
+    """Service dependencies set by Smart Mapping (subset of answers['depends_on'])."""
 
     parent_service: str | None = None
-    """Имя родительского сервиса, если Smart Mapping обнаружил связанный сервис."""
+    """Parent service name when Smart Mapping finds a related service."""
 
     service_def: dict[str, Any] | None = None
-    """Готовый словарь блока сервиса (результат strategy.build())."""
+    """Built service-block dictionary (result of strategy.build())."""
 
     def as_template_vars(self) -> dict[str, Any]:
         """
-        Возвращает все переменные для Jinja2-рендера.
-        Включает answers + служебные поля контекста.
+        Return all variables for Jinja2 rendering.
+        Includes answers plus service context fields.
         """
         base: dict[str, Any] = {**self.answers}
         base["service_name"] = self.service_name
@@ -101,56 +101,56 @@ class ArtifactContext:
 
 
 # ---------------------------------------------------------------------------
-# Модель описания артефакта
+# Artifact definition model
 # ---------------------------------------------------------------------------
 
 @dataclass
 class ArtifactDef:
-    """Описание companion-файла, генерируемого вместе с сервисом."""
+    """Definition of a companion file generated together with a service."""
 
     relative_path: str
-    """Куда записать файл относительно project_root (например: 'nginx/nginx.conf')."""
+    """Where to write the file relative to project_root (for example: 'nginx/nginx.conf')."""
 
     source_template: str | None = None
-    """Путь к Jinja2-шаблону относительно rdt/templates/artifacts/. Используется при source_type=TEMPLATE."""
+    """Path to a Jinja2 template under rdt/templates/artifacts/. Used when source_type=TEMPLATE."""
 
     source_type: ArtifactSourceType = ArtifactSourceType.TEMPLATE
-    """Тип источника содержимого файла."""
+    """File content source type."""
 
     static_content: str | None = None
-    """Готовый текст файла. Используется при source_type=STATIC."""
+    """Ready-to-write file content. Used when source_type=STATIC."""
 
     renderer: Callable[[ArtifactContext], str] | None = None
-    """Python-рендерер. Используется при source_type=PYTHON."""
+    """Python renderer. Used when source_type=PYTHON."""
 
     overwrite: OverwritePolicy = OverwritePolicy.SKIP
-    """Политика поведения при существующем файле."""
+    """Behavior policy for existing files."""
 
     condition: str | None = None
-    """Ключ в answers — генерировать только если answers[condition] truthy."""
+    """answers key; generate only when answers[condition] is truthy."""
 
     extra_vars: dict[str, Any] = field(default_factory=dict)
-    """Дополнительные переменные для шаблона (поверх context.as_template_vars())."""
+    """Additional template variables layered over context.as_template_vars()."""
 
 
 # ---------------------------------------------------------------------------
-# Результат preflight-проверки
+# Preflight check result
 # ---------------------------------------------------------------------------
 
 @dataclass
 class PreflightIssue:
-    """Одна проблема, найденная при preflight-проверке."""
+    """One issue found during preflight checks."""
     artifact_path: str
     reason: str
 
 
 # ---------------------------------------------------------------------------
-# Результат генерации
+# Generation result
 # ---------------------------------------------------------------------------
 
 @dataclass
 class ArtifactResult:
-    """Результат генерации одного артефакта."""
+    """Generation result for one artifact."""
 
     path: Path
     status: str  # "created" | "skipped" | "overwritten" | "error"
@@ -162,12 +162,12 @@ class ArtifactResult:
 
 
 # ---------------------------------------------------------------------------
-# Запланированное действие (plan → apply)
+# Planned action (plan → apply)
 # ---------------------------------------------------------------------------
 
 @dataclass
 class ArtifactPlan:
-    """Запланированное действие для одного артефакта (до фактической записи)."""
+    """Planned action for one artifact before writing anything."""
 
     artifact: ArtifactDef
     target: Path
@@ -176,21 +176,21 @@ class ArtifactPlan:
 
 
 # ---------------------------------------------------------------------------
-# Pipeline генерации артефактов
+# Artifact generation pipeline
 # ---------------------------------------------------------------------------
 
 class ArtifactPipeline:
     """
-    Pipeline генерации companion-файлов сервиса.
+    Pipeline for generating service companion files.
 
-    Архитектура plan → apply:
-    1. preflight() — проверить шаблоны, пути и политики до записи
-    2. plan()      — построить список запланированных действий без записи
-    3. apply()     — выполнить план: рендер + запись файлов
-    4. run()       — ярлык: plan() → apply()
+    plan → apply architecture:
+    1. preflight() — check templates, paths, and policies before writing
+    2. plan()      — build a list of planned actions without writing
+    3. apply()     — execute the plan: render + write files
+    4. run()       — shortcut for plan() → apply()
     """
 
-    #: Директория с шаблонами артефактов (внутри пакета rdt)
+    #: Directory containing artifact templates inside the rdt package.
     TEMPLATES_DIR: Path = Path(__file__).parent / "templates" / "artifacts"
 
     def __init__(
@@ -203,7 +203,7 @@ class ArtifactPipeline:
 
     @property
     def base_dir(self) -> Path:
-        """Корень проекта из контекста."""
+        """Project root from the context."""
         return self.context.project_root
 
     # ---------------------------------------------------------------------------
@@ -212,18 +212,18 @@ class ArtifactPipeline:
 
     def preflight(self) -> list[PreflightIssue]:
         """
-        Проверить готовность всех активных артефактов к генерации.
-        Возвращает список найденных проблем (пустой — значит всё ок).
+        Check whether all active artifacts are ready to generate.
+        Returns found issues; an empty list means everything is okay.
         """
         issues: list[PreflightIssue] = []
         for artifact in self.artifacts:
-            # Пропустить если условие не выполнено
+            # Skip when the condition is not satisfied.
             if artifact.condition and not self.context.answers.get(artifact.condition):
                 continue
 
             target = self.base_dir / artifact.relative_path
 
-            # 1. Проверить источник содержимого
+            # 1. Check the content source.
             if artifact.source_type == ArtifactSourceType.TEMPLATE:
                 if artifact.source_template is None:
                     issues.append(PreflightIssue(
@@ -248,14 +248,14 @@ class ArtifactPipeline:
                     reason=t("artifacts.preflight.renderer_missing"),
                 ))
 
-            # 2. Проверить политику при существующем файле
+            # 2. Check the existing-file policy.
             if target.exists() and artifact.overwrite == OverwritePolicy.ERROR_IF_EXISTS:
                 issues.append(PreflightIssue(
                     artifact_path=artifact.relative_path,
                     reason=t("artifacts.preflight.file_exists", path=str(target)),
                 ))
 
-            # 3. Проверить доступность родительской директории (если уже существует)
+            # 3. Check parent directory availability when it already exists.
             parent = target.parent
             if parent.exists() and not parent.is_dir():
                 issues.append(PreflightIssue(
@@ -271,8 +271,8 @@ class ArtifactPipeline:
 
     def plan(self) -> list[ArtifactPlan]:
         """
-        Определить что будет сделано с каждым активным артефактом без фактической записи.
-        Возвращает список ArtifactPlan с action: create | overwrite | skip | error.
+        Determine what will happen to each active artifact without writing anything.
+        Returns ArtifactPlan entries with action: create | overwrite | skip | error.
         """
         plans: list[ArtifactPlan] = []
         for artifact in self.artifacts:
@@ -304,7 +304,7 @@ class ArtifactPipeline:
     # ---------------------------------------------------------------------------
 
     def apply(self, plans: list[ArtifactPlan]) -> list[ArtifactResult]:
-        """Выполнить план: рендер + запись для активных артефактов."""
+        """Execute the plan: render and write active artifacts."""
         results: list[ArtifactResult] = []
         for plan in plans:
             if plan.action == "skip":
@@ -330,11 +330,11 @@ class ArtifactPipeline:
         return results
 
     # ---------------------------------------------------------------------------
-    # Run (ярлык: plan → apply)
+    # Run (shortcut: plan → apply)
     # ---------------------------------------------------------------------------
 
     def run(self) -> list[ArtifactResult]:
-        """Запустить pipeline: plan() → apply() → результаты."""
+        """Run the pipeline: plan() → apply() → results."""
         return self.apply(self.plan())
 
     # ---------------------------------------------------------------------------
@@ -342,7 +342,7 @@ class ArtifactPipeline:
     # ---------------------------------------------------------------------------
 
     def _render(self, artifact: ArtifactDef) -> str:
-        """Отрендерить содержимое артефакта в зависимости от source_type."""
+        """Render artifact content according to source_type."""
         if artifact.source_type == ArtifactSourceType.TEMPLATE:
             return self._render_template(artifact)
         elif artifact.source_type == ArtifactSourceType.STATIC:
@@ -357,7 +357,7 @@ class ArtifactPipeline:
             raise ValueError(f"Unknown source_type: {artifact.source_type}")
 
     def _render_template(self, artifact: ArtifactDef) -> str:
-        """Отрендерить Jinja2-шаблон с полным контекстом + extra_vars."""
+        """Render a Jinja2 template with the full context plus extra_vars."""
         env = Environment(
             loader=FileSystemLoader(str(self.TEMPLATES_DIR)),
             autoescape=False,
@@ -368,12 +368,12 @@ class ArtifactPipeline:
         return template.render(**ctx)
 
     # ---------------------------------------------------------------------------
-    # Вывод результатов пользователю
+    # User-facing result output
     # ---------------------------------------------------------------------------
 
     @staticmethod
     def print_results(results: list[ArtifactResult], console: Any) -> None:
-        """Вывести понятный отчёт о сгенерированных артефактах."""
+        """Print a readable report for generated artifacts."""
         if not results:
             return
 
@@ -393,62 +393,61 @@ class ArtifactPipeline:
 
     @staticmethod
     def has_errors(results: list[ArtifactResult]) -> bool:
-        """Вернуть True если хотя бы один артефакт завершился с ошибкой."""
+        """Return True when at least one artifact failed."""
         return any(r.has_error for r in results)
 
 
 # ---------------------------------------------------------------------------
-# P2: Bootstrap Hint — подсказка для пользователя о ручных шагах
+# P2: Bootstrap Hint — user guidance for manual steps
 # ---------------------------------------------------------------------------
 
 @dataclass
 class BootstrapHint:
     """
-    Подсказка о ручных шагах, которые нужно выполнить после добавления сервиса.
+    Hint about manual steps to perform after adding a service.
 
-    Используется для инструкций, которые нельзя автоматизировать
-    (например, запуск команды инициализации внутри контейнера).
-    Намеренно не выполняется автоматически — только отображается пользователю.
+    Used for instructions that cannot be automated, such as running an
+    initialization command inside a container. Intentionally displayed only;
+    RDT does not execute these steps automatically.
     """
 
     message: str
-    """Текст подсказки (что нужно сделать)."""
+    """Hint text describing what should be done."""
 
     command: str | None = None
-    """Опциональная команда для отображения (только справочно, не выполняется RDT)."""
+    """Optional command to display for reference only; RDT does not execute it."""
 
 
 # ---------------------------------------------------------------------------
-# P2: Directory Scaffolding — декларативное создание директорий
+# P2: Directory Scaffolding — declarative directory creation
 # ---------------------------------------------------------------------------
 
 @dataclass
 class DirectoryDef:
     """
-    Описание директории, которую нужно создать при scaffolding.
+    Definition of a directory to create during scaffolding.
 
-    Используется для объявления структуры проекта, которая должна существовать
-    ещё до того, как в неё будут записаны конкретные файлы (артефакты).
-    Например: logstash/pipeline/, logstash/config/.
+    Used to declare project structure that should exist before specific files
+    (artifacts) are written into it. Examples: logstash/pipeline/, logstash/config/.
     """
 
     relative_path: str
-    """Путь к директории относительно project_root."""
+    """Directory path relative to project_root."""
 
 
 @dataclass
 class ScaffoldPlan:
-    """Запланированное действие для одной директории (до создания)."""
+    """Planned action for one directory before creation."""
 
     directory: DirectoryDef
     target: Path
     action: Literal["create", "skip"]
-    """create — директория будет создана; skip — уже существует."""
+    """create means the directory will be created; skip means it already exists."""
 
 
 @dataclass
 class ScaffoldResult:
-    """Результат создания одной директории при scaffolding."""
+    """Result of creating one directory during scaffolding."""
 
     path: Path
     status: str  # "created" | "already_exists" | "error"
@@ -461,12 +460,12 @@ class ScaffoldResult:
 
 class ScaffoldPipeline:
     """
-    Pipeline декларативного создания директорий.
+    Pipeline for declarative directory creation.
 
-    Архитектура plan → apply:
-    1. plan()  — определить какие директории нужно создать (без записи)
-    2. apply() — создать директории по плану
-    3. run()   — ярлык: plan() → apply()
+    plan → apply architecture:
+    1. plan()  — determine which directories to create without writing
+    2. apply() — create directories according to the plan
+    3. run()   — shortcut for plan() → apply()
     """
 
     def __init__(self, directories: list[DirectoryDef], project_root: Path) -> None:
@@ -474,7 +473,7 @@ class ScaffoldPipeline:
         self.project_root = project_root
 
     def plan(self) -> list[ScaffoldPlan]:
-        """Определить действие для каждой директории без фактического создания."""
+        """Determine the action for each directory without creating anything."""
         plans: list[ScaffoldPlan] = []
         for dir_def in self.directories:
             target = self.project_root / dir_def.relative_path
@@ -483,7 +482,7 @@ class ScaffoldPipeline:
         return plans
 
     def apply(self, plans: list[ScaffoldPlan]) -> list[ScaffoldResult]:
-        """Выполнить план: создать директории, вернуть результаты."""
+        """Execute the plan: create directories and return results."""
         results: list[ScaffoldResult] = []
         for plan in plans:
             if plan.action == "skip":
@@ -497,17 +496,17 @@ class ScaffoldPipeline:
         return results
 
     def run(self) -> list[ScaffoldResult]:
-        """Запустить pipeline: plan() → apply() → результаты."""
+        """Run the pipeline: plan() → apply() → results."""
         return self.apply(self.plan())
 
     @staticmethod
     def has_errors(results: list[ScaffoldResult]) -> bool:
-        """Вернуть True если хотя бы одна директория завершилась с ошибкой."""
+        """Return True when at least one directory operation failed."""
         return any(r.has_error for r in results)
 
     @staticmethod
     def print_results(results: list[ScaffoldResult], console: Any) -> None:
-        """Вывести понятный отчёт о scaffolding-операциях."""
+        """Print a readable report for scaffolding operations."""
         if not results:
             return
         console.print()

--- a/rdt/cli.py
+++ b/rdt/cli.py
@@ -1,9 +1,9 @@
 """
-CLI точка входа для RDT (Rambo Docker Tools).
-Команды: init, add, list, up, check, doctor, lang
+CLI entry point for RDT (Rambo Docker Tools).
+Commands: init, add, list, up, check, doctor, lang
 
-Слой ответственности: парсинг аргументов, интерактивный wizard, Rich-вывод.
-Вся бизнес-логика делегируется в rdt.core.
+Responsibilities: argument parsing, interactive wizard, and Rich output.
+All business logic is delegated to rdt.core.
 """
 from __future__ import annotations
 from pathlib import Path
@@ -20,6 +20,8 @@ from rdt.yaml_manager import (
     load_compose,
     get_existing_services,
     get_services_with_healthcheck,
+    DEFAULT_COMPOSE_FILE,
+    resolve_default_compose_file,
 )
 from rdt.wizard import run_wizard, run_main_menu, ask_service_choice
 from rdt.i18n import t
@@ -43,15 +45,20 @@ app = typer.Typer(
 )
 console = Console()
 
-COMPOSE_FILE = Path("docker-compose.yml")
+COMPOSE_FILE = Path(DEFAULT_COMPOSE_FILE)
 
 
 def _resolve_project_root(file: Path) -> Path:
     return file.parent.resolve()
 
 
+def _resolve_cli_compose_file(file: Path) -> Path:
+    """Prefer an existing common Compose filename when the default path is used."""
+    return resolve_default_compose_file(file) if file == COMPOSE_FILE else file
+
+
 # ─────────────────────────────────────────────────────────────────────────────
-# Callback — запускает интерактивное меню при rdt без аргументов
+# Callback — starts the interactive menu when rdt is run without arguments
 # ─────────────────────────────────────────────────────────────────────────────
 @app.callback(invoke_without_command=True, help=t("app.callback_help"))
 def main(ctx: typer.Context) -> None:
@@ -60,7 +67,7 @@ def main(ctx: typer.Context) -> None:
 
 
 def _run_interactive(ctx: typer.Context) -> None:
-    """Запустить главное интерактивное меню."""
+    """Start the main interactive menu."""
     while True:
         action = run_main_menu()
 
@@ -105,7 +112,7 @@ def _run_interactive(ctx: typer.Context) -> None:
 
         elif action == "lang":
             _change_language()
-            continue  # Меню сразу перерисуется с новым языком
+            continue  # The menu is redrawn immediately with the new language.
 
         console.print()
         cont = questionary.confirm(t("msg.do_more"), default=False).ask()
@@ -114,12 +121,12 @@ def _run_interactive(ctx: typer.Context) -> None:
 
 
 def _show_help(ctx: typer.Context) -> None:
-    """Вывести полную справку по командам RDT (аналог rdt --help)."""
+    """Print the full RDT command help, equivalent to rdt --help."""
     console.print(ctx.get_help())
 
 
 def _change_language() -> None:
-    """Интерактивная смена языка прямо внутри сессии."""
+    """Interactively change the language inside the current session."""
     langs = i18n.available_langs()
     current = i18n.current_lang()
     choices = [
@@ -144,6 +151,7 @@ def init(
     file: Annotated[Path, typer.Option("--file", "-f", help=t("cmd.init.opt_file"))] = COMPOSE_FILE,
     force: Annotated[bool, typer.Option("--force", help=t("cmd.init.opt_force"))] = False,
 ) -> None:
+    file = _resolve_cli_compose_file(file)
     try:
         result = core_init(file, force=force)
     except RdtError as e:
@@ -176,6 +184,7 @@ def add(
     hc_start_period: Annotated[Optional[str], typer.Option("--hc-start-period", help=t("cmd.add.opt_hc_start_period"))] = None,
     set_params: Annotated[Optional[list[str]], typer.Option("--set", help=t("cmd.add.opt_set"))] = None,
 ) -> None:
+    file = _resolve_cli_compose_file(file)
     service = service.lower()
     preset = ALL_PRESETS.get(service)
     if preset is None:
@@ -183,7 +192,7 @@ def add(
         console.print(t("msg.use_rdt_list"))
         raise typer.Exit(1)
 
-    # Парсинг --set key=value
+    # Parse --set key=value.
     set_overrides: dict[str, str] = {}
     for param in (set_params or []):
         if "=" not in param:
@@ -219,7 +228,7 @@ def add(
                 set_vars=set_overrides or None,
             )
         else:
-            # Wizard mode — интерактивный режим остаётся в CLI
+            # Wizard mode remains interactive in the CLI.
             if file.exists():
                 data = load_compose(file)
                 existing = get_existing_services(data)
@@ -293,6 +302,7 @@ def up(
     file: Annotated[Path, typer.Option("--file", "-f", help=t("cmd.up.opt_file"))] = COMPOSE_FILE,
     detach: Annotated[bool, typer.Option("--detach/--no-detach", "-d", help=t("cmd.up.opt_detach"))] = True,
 ) -> None:
+    file = _resolve_cli_compose_file(file)
     try:
         result = core_up(file, detach=detach)
     except RdtError as e:
@@ -310,6 +320,7 @@ def check(
     file: Annotated[Path, typer.Option("--file", "-f", help=t("cmd.check.opt_file"))] = COMPOSE_FILE,
     verbose: Annotated[bool, typer.Option("--verbose", "-v", help=t("cmd.check.opt_verbose"))] = False,
 ) -> None:
+    file = _resolve_cli_compose_file(file)
     console.print(t("msg.check_running", file=file))
     try:
         result = core_check(file)
@@ -338,6 +349,7 @@ def remove(
     clean_env: Annotated[bool, typer.Option("--clean-env", help=t("cmd.remove.opt_clean_env"))] = False,
     clean_artifacts: Annotated[bool, typer.Option("--clean-artifacts", help=t("cmd.remove.opt_clean_artifacts"))] = False,
 ) -> None:
+    file = _resolve_cli_compose_file(file)
     if not file.exists():
         console.print(t("remove.compose_not_found", file=file))
         raise typer.Exit(1)
@@ -349,7 +361,7 @@ def remove(
         console.print(t("remove.no_services", file=file))
         raise typer.Exit(1)
 
-    # ── Выбор сервиса (interactive или аргумент) ─────────────────────────────
+    # ── Service selection (interactive or argument) ──────────────────────────
     if service is None:
         from rdt.wizard import ask_remove_service_choice
         service = ask_remove_service_choice(existing)
@@ -366,7 +378,7 @@ def remove(
 
     console.print(t("remove.header", service=service))
 
-    # ── Интерактивные вопросы по опциям (если не --yes) ─────────────────────
+    # ── Interactive option questions when --yes is not provided ──────────────
     if not yes:
         from rdt.env_manager import find_orphaned_vars
         from rdt.core import _get_artifact_paths
@@ -385,7 +397,7 @@ def remove(
             console.print(t("remove.cancelled"))
             raise typer.Exit(0)
 
-    # ── Применение (делегируем в core) ───────────────────────────────────────
+    # ── Apply through core ───────────────────────────────────────────────────
     try:
         result = core_remove(service, file, clean_env=clean_env, clean_artifacts=clean_artifacts)
     except RdtError as e:
@@ -441,6 +453,7 @@ _CHECK_LABEL_KEYS = {
 def doctor(
     file: Annotated[Path, typer.Option("--file", "-f", help=t("cmd.doctor.opt_file"))] = COMPOSE_FILE,
 ) -> None:
+    file = _resolve_cli_compose_file(file)
     console.print(t("doctor.header"))
 
     try:
@@ -493,7 +506,7 @@ def lang_cmd(
     action: Annotated[Optional[str], typer.Argument(help=t("cmd.lang.arg_action"))] = None,
     value: Annotated[Optional[str], typer.Argument(help=t("cmd.lang.arg_value"))] = None,
 ) -> None:
-    # Без аргументов — интерактивный выбор языка
+    # No arguments: choose the language interactively.
     if action is None:
         _change_language()
         return
@@ -518,7 +531,7 @@ def lang_cmd(
             raise typer.Exit(1)
         return
 
-    # Неизвестное действие
+    # Unknown action.
     console.print(t("lang.unknown", lang=action))
     raise typer.Exit(1)
 

--- a/rdt/core.py
+++ b/rdt/core.py
@@ -1,9 +1,9 @@
 """
-RDT Core — бизнес-логика без CLI-зависимостей (Rich / Typer / questionary).
+RDT Core — business logic without CLI dependencies (Rich / Typer / questionary).
 
-Используется MCP-сервером и может использоваться любым другим клиентом.
-Все функции принимают типизированные параметры и возвращают dataclass-результаты.
-При ошибках бросают RdtError.
+Used by the MCP server and available to any other client.
+All functions accept typed parameters and return dataclass results.
+Errors are raised as RdtError.
 """
 from __future__ import annotations
 
@@ -32,15 +32,15 @@ from rdt.artifacts import (
 from rdt.doctor import run_all_checks
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Исключение
+# Exception
 # ─────────────────────────────────────────────────────────────────────────────
 
 class RdtError(Exception):
-    """Ошибка бизнес-логики RDT."""
+    """RDT business-logic error."""
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Результирующие типы
+# Result types
 # ─────────────────────────────────────────────────────────────────────────────
 
 @dataclass
@@ -97,11 +97,11 @@ class UpResult:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Вспомогательные функции
+# Helper functions
 # ─────────────────────────────────────────────────────────────────────────────
 
 def _resolve_root(file: Path) -> Path:
-    """Определить project root по аналогии с CLI."""
+    """Resolve the project root in the same way as the CLI."""
     return file.parent.resolve()
 
 
@@ -121,7 +121,7 @@ def _get_artifact_paths(service_name: str, project_root: Path) -> list[Path]:
 # ─────────────────────────────────────────────────────────────────────────────
 
 def init(file: Path, force: bool = False) -> InitResult:
-    """Создать базовый docker-compose.yml, .env и .env.example."""
+    """Create base docker-compose.yml, .env, and .env.example files."""
     if file.exists() and not force:
         raise RdtError(f"File already exists: {file}. Use force=True to overwrite.")
 
@@ -164,7 +164,7 @@ def add(
     hc_start_period: str | None = None,
     set_vars: dict[str, str] | None = None,
 ) -> AddResult:
-    """Добавить сервис в docker-compose.yml (script/MCP mode)."""
+    """Add a service to docker-compose.yml in script/MCP mode."""
     service = service.lower()
     preset = ALL_PRESETS.get(service)
     if preset is None:
@@ -212,7 +212,7 @@ def add_from_answers(
     file: Path,
     hardcore: bool = False,
 ) -> AddResult:
-    """Добавить сервис, используя готовый словарь answers (wizard mode в CLI)."""
+    """Add a service using a prepared answers dict from CLI wizard mode."""
     service = service.lower()
     preset = ALL_PRESETS.get(service)
     if preset is None:
@@ -235,13 +235,13 @@ def _apply_add(
     file: Path,
     hardcore: bool,
 ) -> AddResult:
-    """Применить answers к compose/env/artifacts — общий apply-путь."""
+    """Apply answers to compose/env/artifacts through the shared apply path."""
     svc_key = preset.name
     project_root = _resolve_root(file)
     env_file = project_root / ".env"
     env_example = project_root / ".env.example"
 
-    # Compose в памяти
+    # Compose data in memory.
     if file.exists():
         data = load_compose(file)
         compose_was_new = False
@@ -299,14 +299,14 @@ def _apply_add(
             )
         artifact_plans = pipeline.plan()
 
-    # Снимки для rollback
+    # Snapshots for rollback.
     compose_snapshot: str | None = file.read_text(encoding="utf-8") if file.exists() else None
     env_existed = env_file.exists()
     env_snapshot: str | None = env_file.read_text(encoding="utf-8") if env_existed else None
     env_ex_existed = env_example.exists()
     env_ex_snapshot: str | None = env_example.read_text(encoding="utf-8") if env_ex_existed else None
 
-    # ── Запись на диск ────────────────────────────────────────────────────────
+    # ── Write to disk ─────────────────────────────────────────────────────────
     save_compose(file, data)
     write_env(env_file, env_values)
     write_env_example(env_example, env_values)
@@ -346,7 +346,7 @@ def _apply_add(
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# _rollback (внутренний)
+# _rollback (internal)
 # ─────────────────────────────────────────────────────────────────────────────
 
 def _rollback(
@@ -362,7 +362,7 @@ def _rollback(
     scaffold_results: list[ScaffoldResult],
     artifact_results: list[ArtifactResult],
 ) -> None:
-    """Best-effort rollback при ошибке применения."""
+    """Best-effort rollback after an apply error."""
     try:
         if compose_was_new:
             if compose_file.exists():
@@ -413,7 +413,7 @@ def remove(
     clean_env: bool = False,
     clean_artifacts: bool = False,
 ) -> RemoveResult:
-    """Удалить сервис из docker-compose.yml."""
+    """Remove a service from docker-compose.yml."""
     if not file.exists():
         raise RdtError(f"Compose file not found: {file}")
 
@@ -472,7 +472,7 @@ def remove(
 # ─────────────────────────────────────────────────────────────────────────────
 
 def list_presets(category: str | None = None) -> list[PresetInfo]:
-    """Вернуть список доступных пресетов."""
+    """Return the list of available presets."""
     result = []
     for preset in ALL_PRESETS.values():
         if category and preset.category.lower() != category.lower():
@@ -494,7 +494,7 @@ def list_presets(category: str | None = None) -> list[PresetInfo]:
 # ─────────────────────────────────────────────────────────────────────────────
 
 def doctor(file: Path) -> DoctorResult:
-    """Запустить полную диагностику проекта."""
+    """Run full project diagnostics."""
     project_root = _resolve_root(file)
     results = run_all_checks(file, project_root)
 
@@ -521,7 +521,7 @@ def doctor(file: Path) -> DoctorResult:
 # ─────────────────────────────────────────────────────────────────────────────
 
 def check(file: Path) -> ComposeCheckResult:
-    """Проверить валидность docker-compose.yml через docker compose config."""
+    """Validate docker-compose.yml through docker compose config."""
     if not file.exists():
         raise RdtError(f"Compose file not found: {file}")
 
@@ -539,7 +539,7 @@ def check(file: Path) -> ComposeCheckResult:
 # ─────────────────────────────────────────────────────────────────────────────
 
 def up(file: Path, detach: bool = True) -> UpResult:
-    """Запустить docker compose up."""
+    """Run docker compose up."""
     if not file.exists():
         raise RdtError(f"Compose file not found: {file}")
 

--- a/rdt/doctor.py
+++ b/rdt/doctor.py
@@ -1,14 +1,14 @@
 """
-rdt doctor — полная диагностика Docker-проекта.
+rdt doctor — full Docker project diagnostics.
 
 Checks:
-  1. Docker доступен (docker --version)
-  2. Docker Compose v2 доступен (docker compose version)
-  3. compose-файл валиден (docker compose config)
-  4. Все ${VAR} в compose покрыты значениями из .env
-  5. Порты, прокинутые в compose, не заняты на хосте
-  6. depends_on не ссылается на несуществующие сервисы
-  7. Bind-mounted файлы (companion-файлы) существуют на диске
+  1. Docker is available (docker --version)
+  2. Docker Compose v2 is available (docker compose version)
+  3. The compose file is valid (docker compose config)
+  4. All ${VAR} references in compose are covered by .env values
+  5. Ports published by compose are not busy on the host
+  6. depends_on does not reference missing services
+  7. Bind-mounted files (companion files) exist on disk
 """
 from __future__ import annotations
 
@@ -24,7 +24,7 @@ from rdt.yaml_manager import load_compose
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Типы результатов
+# Result types
 # ─────────────────────────────────────────────────────────────────────────────
 
 @dataclass
@@ -36,11 +36,11 @@ class CheckResult:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Вспомогательные функции
+# Helper functions
 # ─────────────────────────────────────────────────────────────────────────────
 
 def _parse_host_port(port_str: str) -> int | None:
-    """Извлечь host-порт из строки маппинга docker-compose."""
+    """Extract the host port from a docker-compose port mapping string."""
     port_str = str(port_str).strip("\"'")
     port_str = re.sub(r"/(tcp|udp)$", "", port_str)
     parts = port_str.split(":")
@@ -55,7 +55,7 @@ def _parse_host_port(port_str: str) -> int | None:
 
 
 def _load_env_values(env_file: Path) -> dict[str, str]:
-    """Загрузить переменные из .env без зависимости от dotenv."""
+    """Load variables from .env without depending on dotenv."""
     values: dict[str, str] = {}
     if not env_file.exists():
         return values
@@ -69,7 +69,7 @@ def _load_env_values(env_file: Path) -> dict[str, str]:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Проверка 1 — Docker установлен и работает
+# Check 1 — Docker is installed and running
 # ─────────────────────────────────────────────────────────────────────────────
 
 def check_docker_available() -> CheckResult:
@@ -85,7 +85,7 @@ def check_docker_available() -> CheckResult:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Проверка 2 — Docker Compose v2 доступен
+# Check 2 — Docker Compose v2 is available
 # ─────────────────────────────────────────────────────────────────────────────
 
 def check_compose_available() -> CheckResult:
@@ -101,7 +101,7 @@ def check_compose_available() -> CheckResult:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Проверка 3 — compose-файл проходит `docker compose config`
+# Check 3 — compose file passes `docker compose config`
 # ─────────────────────────────────────────────────────────────────────────────
 
 def check_compose_valid(file: Path) -> CheckResult:
@@ -123,7 +123,7 @@ def check_compose_valid(file: Path) -> CheckResult:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Проверка 4 — все ${VAR} в compose покрыты значениями из .env
+# Check 4 — all ${VAR} references in compose are covered by .env
 # ─────────────────────────────────────────────────────────────────────────────
 
 def check_env_vars(file: Path, project_root: Path) -> CheckResult:
@@ -137,7 +137,7 @@ def check_env_vars(file: Path, project_root: Path) -> CheckResult:
         return CheckResult("env_vars", "ok", t("doctor.env_no_vars"))
 
     env_values = _load_env_values(project_root / ".env")
-    # Системные переменные тоже в счёт
+    # System environment variables count too.
     for k, v in os.environ.items():
         env_values.setdefault(k, v)
 
@@ -150,7 +150,7 @@ def check_env_vars(file: Path, project_root: Path) -> CheckResult:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Проверка 5 — порты, прокинутые в compose, не заняты на хосте
+# Check 5 — ports published by compose are not busy on the host
 # ─────────────────────────────────────────────────────────────────────────────
 
 def check_port_conflicts(file: Path) -> CheckResult:
@@ -176,7 +176,7 @@ def check_port_conflicts(file: Path) -> CheckResult:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Проверка 6 — depends_on не ссылается на несуществующие сервисы
+# Check 6 — depends_on does not reference missing services
 # ─────────────────────────────────────────────────────────────────────────────
 
 def check_dangling_depends_on(file: Path) -> CheckResult:
@@ -204,7 +204,7 @@ def check_dangling_depends_on(file: Path) -> CheckResult:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Проверка 7 — bind-mount'ированные файлы существуют
+# Check 7 — bind-mounted files exist
 # ─────────────────────────────────────────────────────────────────────────────
 
 def check_companion_files(file: Path, project_root: Path) -> CheckResult:
@@ -216,13 +216,13 @@ def check_companion_files(file: Path, project_root: Path) -> CheckResult:
     missing: list[tuple[str, str]] = []
 
     def _check_path(svc: str, src: str) -> None:
-        # Bind-mounts: начинаются с . / ..
+        # Bind mounts start with . / ..
         if not (src.startswith("./") or src.startswith("../") or (src.startswith("/") and len(src) > 1)):
             return
         resolved = (project_root / src).resolve()
         if resolved.exists():
             return
-        # Файлы (с расширением или точкой в имени) — сообщаем как отсутствующий companion
+        # File-like paths (extension or dot in name) are reported as missing companions.
         if resolved.suffix or "." in resolved.name:
             missing.append((svc, src))
 
@@ -233,7 +233,7 @@ def check_companion_files(file: Path, project_root: Path) -> CheckResult:
             src = str(vol).split(":")[0]
             _check_path(svc_name, src)
 
-    # Верхнеуровневые configs / secrets
+    # Top-level configs / secrets.
     for section in ("configs", "secrets"):
         for _key, cfg in (data.get(section) or {}).items():
             if isinstance(cfg, dict) and (src := cfg.get("file")):
@@ -250,7 +250,7 @@ def check_companion_files(file: Path, project_root: Path) -> CheckResult:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Публичный агрегатор — запускает все проверки и возвращает список результатов
+# Public aggregator — runs all checks and returns their results
 # ─────────────────────────────────────────────────────────────────────────────
 
 def run_all_checks(file: Path, project_root: Path) -> list[CheckResult]:

--- a/rdt/env_manager.py
+++ b/rdt/env_manager.py
@@ -1,5 +1,5 @@
 """
-Управление .env и .env.example файлами.
+Manage .env and .env.example files.
 """
 from __future__ import annotations
 import re
@@ -7,13 +7,13 @@ import secrets
 import string
 from pathlib import Path
 
-# Regex для извлечения имён переменных из ${VAR_NAME} в любом контексте
+# Regex for extracting variable names from ${VAR_NAME} in any context.
 _VAR_PATTERN = re.compile(r'\$\{([^}]+)\}')
 
-# Переменные, которые считаются секретами
+# Variables considered secrets.
 _PASSWORD_KEYS = {"PASSWORD", "SECRET", "PASS", "KEY", "TOKEN"}
 
-# Стандартные credentials для каждого сервиса
+# Default credentials for each service.
 SERVICE_DEFAULTS: dict[str, str] = {
     # PostgreSQL
     "POSTGRES_USER": "postgres",
@@ -29,7 +29,7 @@ SERVICE_DEFAULTS: dict[str, str] = {
     "MARIADB_USER": "mariadb",
     "MARIADB_PASSWORD": "mariadb",
     "MARIADB_DATABASE": "mariadb",
-    # MS SQL (должен соответствовать политике сложности)
+    # MS SQL (must satisfy the complexity policy)
     "MSSQL_SA_PASSWORD": "Sa_Password1!",
     # Oracle
     "ORACLE_PASSWORD": "oracle",
@@ -44,7 +44,7 @@ SERVICE_DEFAULTS: dict[str, str] = {
     "INFLUXDB_PASSWORD": "influx",
     # Elasticsearch
     "ELASTIC_PASSWORD": "elastic",
-    # OpenSearch (должен быть сложным)
+    # OpenSearch (must be complex)
     "OPENSEARCH_PASSWORD": "0penSearch!",
     # RabbitMQ
     "RABBITMQ_USER": "guest",
@@ -76,7 +76,7 @@ def generate_password(length: int = 24) -> str:
 
 
 def _fallback_value(var_name: str) -> str:
-    """Запасное значение если переменной нет в SERVICE_DEFAULTS."""
+    """Fallback value when a variable is not present in SERVICE_DEFAULTS."""
     u = var_name.upper()
     if is_secret_key(var_name):
         return "password"
@@ -91,9 +91,9 @@ def _fallback_value(var_name: str) -> str:
 
 def get_env_values(preset_env: dict[str, str], hardcore: bool) -> dict[str, str]:
     """
-    Возвращает конкретные значения для .env переменных.
-    Использует regex для безопасного извлечения имён переменных из любого контекста.
-    hardcore=True → генерировать уникальные пароли.
+    Return concrete values for .env variables.
+    Uses a regex to safely extract variable names from any context.
+    hardcore=True means unique passwords are generated.
     """
     result: dict[str, str] = {}
     for placeholder in preset_env.values():
@@ -111,7 +111,7 @@ def get_env_values(preset_env: dict[str, str], hardcore: bool) -> dict[str, str]
 
 
 def write_env(env_path: Path, values: dict[str, str]) -> None:
-    """Дописать недостающие переменные в .env файл."""
+    """Append missing variables to the .env file."""
     existing: dict[str, str] = {}
     if env_path.exists():
         for line in env_path.read_text(encoding="utf-8").splitlines():
@@ -131,12 +131,12 @@ def write_env(env_path: Path, values: dict[str, str]) -> None:
 
 
 def extract_vars_from_text(text: str) -> set[str]:
-    """Извлечь все имена переменных вида ${VAR} из произвольного текста."""
+    """Extract all ${VAR}-style variable names from arbitrary text."""
     return set(_VAR_PATTERN.findall(text))
 
 
 def get_service_env_vars(data: Any, service_name: str) -> set[str]:
-    """Вернуть все ${VAR} переменные, используемые конкретным сервисом в compose-данных."""
+    """Return all ${VAR} variables used by a specific service in compose data."""
     import io
     try:
         from ruamel.yaml import YAML
@@ -152,7 +152,7 @@ def get_service_env_vars(data: Any, service_name: str) -> set[str]:
 
 
 def get_all_env_vars_except(data: Any, exclude_service: str) -> set[str]:
-    """Вернуть все ${VAR} переменные, используемые всеми сервисами КРОМЕ указанного."""
+    """Return all ${VAR} variables used by all services except the specified one."""
     import io
     result: set[str] = set()
     try:
@@ -175,9 +175,9 @@ def find_orphaned_vars(
     data: Any,
     service_name: str,
 ) -> set[str]:
-    """Найти переменные ${VAR}, которые используются только удаляемым сервисом.
+    """Find ${VAR} variables used only by the service being removed.
 
-    Возвращает множество имён переменных, которые безопасно удалить из .env.
+    Returns variable names that can be safely removed from .env.
     """
     service_vars = get_service_env_vars(data, service_name)
     remaining_vars = get_all_env_vars_except(data, exclude_service=service_name)
@@ -185,9 +185,9 @@ def find_orphaned_vars(
 
 
 def remove_vars_from_env_file(env_path: Path, vars_to_remove: set[str]) -> int:
-    """Удалить указанные переменные из .env файла (in-place).
+    """Remove the specified variables from the .env file in place.
 
-    Возвращает количество удалённых строк.
+    Returns the number of removed lines.
     """
     if not env_path.exists() or not vars_to_remove:
         return 0
@@ -204,14 +204,14 @@ def remove_vars_from_env_file(env_path: Path, vars_to_remove: set[str]) -> int:
                 continue
         new_lines.append(line)
 
-    # Убрать trailing пустые строки, добавленные при write_env
+    # Remove trailing blank lines added by write_env.
     content = "".join(new_lines).rstrip("\n") + "\n" if new_lines else ""
     env_path.write_text(content, encoding="utf-8")
     return removed
 
 
 def write_env_example(example_path: Path, values: dict[str, str]) -> None:
-    """Записать/обновить .env.example с пустыми значениями."""
+    """Write/update .env.example with empty values."""
     existing_keys: set[str] = set()
     if example_path.exists():
         for line in example_path.read_text(encoding="utf-8").splitlines():

--- a/rdt/mcp_server.py
+++ b/rdt/mcp_server.py
@@ -1,17 +1,17 @@
 """
-RDT MCP Server — Model Context Protocol сервер для Rambo Docker Tools.
+RDT MCP Server — Model Context Protocol server for Rambo Docker Tools.
 
-Транспорт: stdio (стандартный для MCP).
-Запуск: rdt-mcp  (entry point определён в pyproject.toml)
+Transport: stdio (the standard MCP transport).
+Run with: rdt-mcp (entry point defined in pyproject.toml).
 
-Инструменты:
-  rdt_init    — инициализировать docker-compose.yml + .env
-  rdt_add     — добавить сервис в стек
-  rdt_remove  — удалить сервис из стека
-  rdt_list    — список доступных пресетов
-  rdt_doctor  — полная диагностика проекта
-  rdt_check   — валидация YAML через docker compose config
-  rdt_up      — запустить docker compose up
+Tools:
+  rdt_init    — initialize docker-compose.yml + .env
+  rdt_add     — add a service to the stack
+  rdt_remove  — remove a service from the stack
+  rdt_list    — list available presets
+  rdt_doctor  — run full project diagnostics
+  rdt_check   — validate YAML via docker compose config
+  rdt_up      — run docker compose up
 """
 from __future__ import annotations
 
@@ -31,35 +31,37 @@ from rdt.core import (
     remove,
     up,
 )
+from rdt.yaml_manager import DEFAULT_COMPOSE_FILE, resolve_default_compose_file
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Экземпляр сервера
+# Server instance
 # ─────────────────────────────────────────────────────────────────────────────
 
 mcp = FastMCP(
     "rdt",
     instructions=(
-        "RDT (Rambo Docker Tools) — генератор production-ready docker-compose стеков. "
-        "Используй rdt_list чтобы узнать доступные сервисы, rdt_init для инициализации проекта, "
-        "rdt_add для добавления сервисов, rdt_doctor для диагностики перед запуском. "
-        "Все инструменты принимают параметр project_dir (абсолютный путь к рабочей директории). "
-        "Если project_dir не задан — используется текущая рабочая директория."
+        "RDT (Rambo Docker Tools) generates production-ready docker-compose stacks. "
+        "Use rdt_list to inspect available services, rdt_init to initialize a project, "
+        "rdt_add to add services, and rdt_doctor to diagnose the stack before startup. "
+        "All tools accept project_dir, an absolute path to the working directory. "
+        "If project_dir is omitted, the current working directory is used."
     ),
 )
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Вспомогательная функция
+# Helper function
 # ─────────────────────────────────────────────────────────────────────────────
 
 def _resolve_file(project_dir: str | None, file: str) -> Path:
-    """Разрешить путь к compose-файлу с учётом project_dir."""
+    """Resolve a compose-file path relative to project_dir when provided."""
     base = Path(project_dir) if project_dir else Path.cwd()
     p = Path(file)
-    return base / p if not p.is_absolute() else p
+    resolved = base / p if not p.is_absolute() else p
+    return resolve_default_compose_file(resolved) if file == DEFAULT_COMPOSE_FILE else resolved
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Инструменты
+# Tools
 # ─────────────────────────────────────────────────────────────────────────────
 
 @mcp.tool()

--- a/rdt/port_utils.py
+++ b/rdt/port_utils.py
@@ -1,5 +1,5 @@
 """
-Утилиты проверки доступности портов на хосте.
+Utilities for checking host port availability.
 """
 from __future__ import annotations
 import socket
@@ -8,18 +8,18 @@ from rdt.i18n import t
 
 
 def is_port_free(port: int, host: str = "127.0.0.1") -> bool:
-    """Возвращает True, если порт свободен на хосте."""
+    """Return True when the port is available on the host."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.settimeout(0.3)
         try:
             s.connect((host, port))
-            return False  # подключились — порт занят
+            return False  # Connection succeeded, so the port is busy.
         except (ConnectionRefusedError, OSError):
-            return True   # не подключились — порт свободен
+            return True   # Connection failed, so the port is available.
 
 
 def find_free_port(start: int, max_tries: int = 20) -> int | None:
-    """Найти ближайший свободный порт начиная с start."""
+    """Find the nearest available port starting at start."""
     for port in range(start, start + max_tries):
         if is_port_free(port):
             return port
@@ -27,7 +27,7 @@ def find_free_port(start: int, max_tries: int = 20) -> int | None:
 
 
 def validate_port(port_str: str) -> tuple[bool, str]:
-    """Валидация строки с номером порта."""
+    """Validate a string containing a port number."""
     try:
         port = int(port_str)
     except ValueError:

--- a/rdt/presets/catalog.py
+++ b/rdt/presets/catalog.py
@@ -1,6 +1,6 @@
 """
-Каталог всех доступных пресетов сервисов.
-Каждый пресет описывает конфигурацию docker-compose сервиса по умолчанию.
+Catalog of all available service presets.
+Each preset describes the default docker-compose configuration for a service.
 """
 from __future__ import annotations
 
@@ -21,21 +21,21 @@ CATEGORY_ADMIN = "Admin Tools"
 
 @dataclass
 class ServicePreset:
-    name: str                          # ключ сервиса (postgres, redis …)
-    display_name: str                  # красивое имя для UI
-    category: str                      # категория из констант выше
+    name: str                          # service key (postgres, redis, etc.)
+    display_name: str                  # display name for the UI
+    category: str                      # category from the constants above
     image: str                         # docker image
-    default_port: int                  # стандартный внешний порт
-    container_port: int                # внутренний порт контейнера
+    default_port: int                  # default external port
+    container_port: int                # internal container port
     default_env: dict = field(default_factory=dict)
-    volumes: list[str] = field(default_factory=list)   # шаблоны volume-маппингов
+    volumes: list[str] = field(default_factory=list)   # volume mapping templates
     healthcheck: Optional[dict] = None
-    deploy_limits: Optional[dict] = None               # CPU / RAM лимиты
+    deploy_limits: Optional[dict] = None               # CPU / RAM limits
     strategy: str = "base"            # base | database | admin_tool | monitoring | web_server
-    depends_on_category: Optional[str] = None          # для Smart Mapping
-    artifacts: list[ArtifactDef] = field(default_factory=list)  # companion-файлы сервиса
-    scaffolds: list[DirectoryDef] = field(default_factory=list)  # директории для scaffolding
-    bootstrap_hints: list[BootstrapHint] = field(default_factory=list)  # подсказки после установки
+    depends_on_category: Optional[str] = None          # for Smart Mapping
+    artifacts: list[ArtifactDef] = field(default_factory=list)  # service companion files
+    scaffolds: list[DirectoryDef] = field(default_factory=list)  # directories for scaffolding
+    bootstrap_hints: list[BootstrapHint] = field(default_factory=list)  # post-install hints
 
 
 # ---------------------------------------------------------------------------
@@ -343,11 +343,11 @@ LOGSTASH = ServicePreset(
     ],
     bootstrap_hints=[
         BootstrapHint(
-            message="Настройте Filebeat/Beats-агент для отправки данных на порт 5044 этого хоста.",
+            message="Configure the Filebeat/Beats agent to send data to port 5044 on this host.",
             command="docker exec -it logstash curl -s http://localhost:9600/_node/stats | python -m json.tool",
         ),
         BootstrapHint(
-            message="Проверьте статус Logstash: убедитесь что pipeline активен и нет ошибок.",
+            message="Check Logstash status and make sure the pipeline is active with no errors.",
         ),
     ],
 )
@@ -683,7 +683,7 @@ NGINX_PROXY = ServicePreset(
     container_port=80,
     default_env={},
     volumes=[],
-    healthcheck=None,          # healthcheck задаётся в WebServerStrategy
+    healthcheck=None,          # healthcheck is set by WebServerStrategy
     deploy_limits={"cpus": "0.5", "memory": "128M"},
     strategy="web_server",
     artifacts=[
@@ -746,7 +746,7 @@ APACHE_STATIC = ServicePreset(
     container_port=80,
     default_env={},
     volumes=[],
-    healthcheck=None,          # healthcheck задаётся в WebServerStrategy
+    healthcheck=None,          # healthcheck is set by WebServerStrategy
     deploy_limits={"cpus": "0.5", "memory": "128M"},
     strategy="web_server",
     artifacts=[
@@ -812,8 +812,8 @@ TRAEFIK = ServicePreset(
     default_port=80,
     container_port=80,
     default_env={},
-    volumes=[],                 # volumes управляются TraefikStrategy
-    healthcheck=None,           # healthcheck задаётся в TraefikStrategy
+    volumes=[],                 # volumes are managed by TraefikStrategy
+    healthcheck=None,           # healthcheck is set by TraefikStrategy
     deploy_limits={"cpus": "0.5", "memory": "128M"},
     strategy="traefik",
     artifacts=[
@@ -829,24 +829,24 @@ TRAEFIK = ServicePreset(
     ],
     bootstrap_hints=[
         BootstrapHint(
-            message="Traefik Dashboard доступен на http://localhost:8080/dashboard/ "
-                    "(по умолчанию insecure-режим). В production отключите insecure и настройте аутентификацию.",
+            message="The Traefik Dashboard is available at http://localhost:8080/dashboard/ "
+                    "(insecure mode by default). Disable insecure mode and configure authentication in production.",
         ),
         BootstrapHint(
-            message="Чтобы Traefik обнаруживал ваши сервисы, добавьте к ним labels:\n"
+            message="To let Traefik discover your services, add these labels:\n"
                     "  traefik.enable=true\n"
                     "  traefik.http.routers.<name>.rule=Host(`your.domain`)\n"
                     "  traefik.http.services.<name>.loadbalancer.server.port=<port>",
         ),
         BootstrapHint(
-            message="Просмотр активных маршрутов и middleware:",
+            message="View active routes and middleware:",
             command="docker exec -it traefik wget -qO- http://localhost:8080/api/http/routers | python -m json.tool",
         ),
     ],
 )
 
 # ---------------------------------------------------------------------------
-# Реестр всех пресетов
+# Registry of all presets
 # ---------------------------------------------------------------------------
 ALL_PRESETS: dict[str, ServicePreset] = {
     p.name: p for p in [

--- a/rdt/smart_mapping.py
+++ b/rdt/smart_mapping.py
@@ -1,13 +1,13 @@
 """
-Smart Mapping — автоматическое предложение связей между сервисами.
+Smart Mapping — automatic suggestions for links between services.
 """
 from __future__ import annotations
 from typing import Any
 
 from rdt.strategies.base import CONTAINER_PREFIX
 
-# Описание умных связок: {service_name: handler_func}
-# handler получает (existing_services: list[str], answers: dict) → обновляет answers["smart_env"]
+# Smart-link definitions: {service_name: handler_func}.
+# A handler receives (existing_services: list[str], answers: dict) and updates answers["smart_env"].
 
 
 def apply_smart_mapping(
@@ -16,8 +16,8 @@ def apply_smart_mapping(
     answers: dict[str, Any],
 ) -> dict[str, Any]:
     """
-    Применяет Smart Mapping для service_name.
-    Возвращает обновлённый словарь answers.
+    Apply Smart Mapping for service_name.
+    Return the updated answers dictionary.
     """
     handlers = {
         "pgadmin": _pgadmin_mapping,
@@ -36,7 +36,7 @@ def apply_smart_mapping(
 
 
 def _pgadmin_mapping(existing: list[str], answers: dict) -> None:
-    """pgAdmin → Postgres: заполнить сервер БД."""
+    """pgAdmin → Postgres: fill in the database server."""
     pg_services = [s for s in existing if "postgres" in s]
     if pg_services:
         selected = answers.get("parent_service", pg_services[0])
@@ -120,7 +120,7 @@ def _logstash_mapping(existing: list[str], answers: dict) -> None:
             deps.append(selected)
         answers["depends_on"] = deps
         answers["parent_service"] = selected
-        # Подсказать дефолтный режим pipeline (но не переопределять если уже задан)
+        # Suggest the default pipeline mode without overriding an existing value.
         answers.setdefault("logstash_pipeline", "beats-es")
         answers.setdefault("logstash_es_host", f"{selected}:9200")
 
@@ -191,7 +191,7 @@ def _kibana_mapping(existing: list[str], answers: dict) -> None:
 
 
 def get_candidate_parents(service_name: str, existing_services: list[str]) -> list[str]:
-    """Вернуть список кандидатов-родителей для smart mapping."""
+    """Return the list of candidate parent services for smart mapping."""
     filters = {
         "pgadmin": lambda s: "postgres" in s,
         "kafka-ui": lambda s: "kafka" in s and "ui" not in s,

--- a/rdt/strategies/admin_tool.py
+++ b/rdt/strategies/admin_tool.py
@@ -1,5 +1,5 @@
 """
-AdminToolStrategy — поиск родительских сервисов, depends_on, без volumes.
+AdminToolStrategy — parent-service lookup, depends_on, no volumes.
 """
 from __future__ import annotations
 from typing import Any
@@ -8,12 +8,12 @@ from rdt.strategies.base import BaseStrategy, CONTAINER_PREFIX
 
 
 class AdminToolStrategy(BaseStrategy):
-    """Стратегия для Admin Tools: автосвязь с родительским сервисом."""
+    """Strategy for Admin Tools: auto-link with a parent service."""
 
     def _enrich(self, service: dict[str, Any]) -> None:
-        # Admin tools не используют volumes
-        # depends_on уже проставлен в BaseStrategy через answers["depends_on"]
-        # Добавляем smart-mapping env если передан
+        # Admin tools do not use volumes.
+        # depends_on is already set by BaseStrategy via answers["depends_on"].
+        # Add smart-mapping env values when provided.
         smart_env = self.answers.get("smart_env", {})
         if smart_env:
             existing = service.get("environment", {})

--- a/rdt/strategies/base.py
+++ b/rdt/strategies/base.py
@@ -1,5 +1,5 @@
 """
-BaseStrategy — общая логика генерации docker-compose блока.
+BaseStrategy — shared docker-compose service block generation logic.
 """
 from __future__ import annotations
 from abc import ABC, abstractmethod
@@ -13,7 +13,7 @@ DEFAULT_RESTART = "unless-stopped"
 
 
 class BaseStrategy(ABC):
-    """Базовая стратегия: имена, сеть, рестарт-политика."""
+    """Base strategy: names, network, and restart policy."""
 
     def __init__(self, preset: ServicePreset, answers: dict[str, Any]) -> None:
         self.preset = preset
@@ -27,7 +27,7 @@ class BaseStrategy(ABC):
         return f"{CONTAINER_PREFIX}{self.preset.name}"
 
     def build(self) -> dict[str, Any]:
-        """Собрать итоговый словарь сервиса для docker-compose."""
+        """Build the final service dictionary for docker-compose."""
         service: dict[str, Any] = {}
         service["image"] = self.preset.image
         service["container_name"] = self.container_name
@@ -37,23 +37,23 @@ class BaseStrategy(ABC):
         net_type = self.answers.get("network_type", "bridge")
         expose_ports = self.answers.get("expose_ports", True)
 
-        # host network_mode — порты не прокидываются явно
+        # host network_mode does not publish ports explicitly.
         if net_type == "host":
             service["network_mode"] = "host"
         else:
-            # Порты
+            # Ports.
             if expose_ports:
                 service["ports"] = [f"{host_port}:{self.preset.container_port}"]
             else:
                 service["expose"] = [str(self.preset.container_port)]
 
-        # Переменные окружения
+        # Environment variables.
         env = dict(self.preset.default_env)
         env.update(self.answers.get("extra_env", {}))
         if env:
             service["environment"] = env
 
-        # Сеть (не нужна для host и none)
+        # Network (not needed for host or none).
         if net_type not in ("host", "none"):
             net_name = self.answers.get("network_name", NETWORK_NAME)
             service["networks"] = [net_name]
@@ -68,7 +68,7 @@ class BaseStrategy(ABC):
                 for dep in deps
             }
 
-        # Лимиты ресурсов
+        # Resource limits.
         if self.preset.deploy_limits:
             service["deploy"] = {
                 "resources": {
@@ -84,5 +84,5 @@ class BaseStrategy(ABC):
 
     @abstractmethod
     def _enrich(self, service: dict[str, Any]) -> None:
-        """Дополнительная логика в подклассах."""
+        """Additional logic implemented by subclasses."""
 

--- a/rdt/strategies/database.py
+++ b/rdt/strategies/database.py
@@ -1,5 +1,5 @@
 """
-DatabaseStrategy — обязательные volumes, healthcheck, credentials.
+DatabaseStrategy — required volumes, healthcheck, and credentials.
 """
 from __future__ import annotations
 from typing import Any
@@ -8,7 +8,7 @@ from rdt.strategies.base import BaseStrategy
 
 
 class DatabaseStrategy(BaseStrategy):
-    """Стратегия для баз данных: volumes + healthcheck обязательны."""
+    """Strategy for databases: volumes + healthcheck are required."""
 
     def _enrich(self, service: dict[str, Any]) -> None:
         # --- Volumes ---

--- a/rdt/strategies/factory.py
+++ b/rdt/strategies/factory.py
@@ -1,5 +1,5 @@
 """
-Фабрика стратегий — возвращает нужную стратегию по пресету.
+Strategy factory — returns the strategy required by a preset.
 """
 from __future__ import annotations
 from typing import Any
@@ -14,7 +14,7 @@ from rdt.strategies.traefik import TraefikStrategy
 
 
 class _FallbackStrategy(BaseStrategy):
-    """Используется когда нет специфичной стратегии."""
+    """Used when no specific strategy exists."""
     def _enrich(self, service: dict) -> None:
         pass
 

--- a/rdt/strategies/monitoring.py
+++ b/rdt/strategies/monitoring.py
@@ -1,5 +1,5 @@
 """
-MonitoringStrategy — специфичные лимиты ресурсов и конфигурационные маппинги.
+MonitoringStrategy — monitoring-specific resource limits and config mappings.
 """
 from __future__ import annotations
 from typing import Any
@@ -8,7 +8,7 @@ from rdt.strategies.base import BaseStrategy
 
 
 class MonitoringStrategy(BaseStrategy):
-    """Стратегия для мониторинга: volumes + healthcheck + config-маппинги."""
+    """Strategy for monitoring services: volumes + healthcheck + config mappings."""
 
     def _enrich(self, service: dict[str, Any]) -> None:
         volume_source = self.answers.get("volume_source", f"{self.preset.name}_data")
@@ -26,7 +26,7 @@ class MonitoringStrategy(BaseStrategy):
             hc.update(custom_hc)
             service["healthcheck"] = hc
 
-        # Дополнительные env-переменные от smart-mapping
+        # Additional env variables from smart mapping.
         smart_env = self.answers.get("smart_env", {})
         if smart_env:
             existing = service.get("environment", {})

--- a/rdt/strategies/traefik.py
+++ b/rdt/strategies/traefik.py
@@ -1,12 +1,12 @@
 """
-TraefikStrategy — стратегия для Traefik reverse proxy.
+TraefikStrategy — strategy for the Traefik reverse proxy.
 
-Особенности:
-- Монтирует /var/run/docker.sock (read-only) для auto-discovery
-- Монтирует конфиг-файл traefik.yml из локальной папки
-- Поддерживает несколько портов: HTTP (80), HTTPS (443), Dashboard (8080)
-- Опциональный Let's Encrypt с хранением сертификатов в ./traefik/certs
-- Healthcheck через ping-эндпоинт на порту API (8080)
+Features:
+- mounts /var/run/docker.sock read-only for auto-discovery
+- mounts traefik.yml from a local directory
+- supports multiple ports: HTTP (80), HTTPS (443), Dashboard (8080)
+- optional Let's Encrypt with certificates stored under ./traefik/certs
+- healthcheck uses the ping endpoint on the API port (8080)
 """
 from __future__ import annotations
 
@@ -18,31 +18,31 @@ from rdt.strategies.base import BaseStrategy
 # Defaults
 # ---------------------------------------------------------------------------
 
-#: Дефолтная директория для конфига Traefik (относительно cwd)
+#: Default Traefik config directory relative to cwd.
 DEFAULT_TRAEFIK_CONFIG_DIR = "./traefik"
 
-#: Порт Dashboard по умолчанию
+#: Default Dashboard port.
 DEFAULT_DASHBOARD_PORT = 8080
 
-#: Порт HTTPS по умолчанию
+#: Default HTTPS port.
 DEFAULT_HTTPS_PORT = 443
 
 
 class TraefikStrategy(BaseStrategy):
     """
-    Стратегия для Traefik reverse proxy.
+    Strategy for the Traefik reverse proxy.
 
-    Отличия от BaseStrategy:
-    - Перезаписывает ports: добавляет HTTPS и Dashboard
-    - Использует bind-mounts (Docker socket + конфиг)
-    - Добавляет healthcheck через /ping API-эндпоинт
+    Differences from BaseStrategy:
+    - overrides ports by adding HTTPS and Dashboard
+    - uses bind mounts (Docker socket + config)
+    - adds a healthcheck through the /ping API endpoint
     """
 
     def _enrich(self, service: dict[str, Any]) -> None:
         net_type = self.answers.get("network_type", "bridge")
         expose_ports = self.answers.get("expose_ports", True)
 
-        # --- Порты ---
+        # --- Ports ---
         if net_type not in ("host", "none") and expose_ports:
             http_port = self.answers.get("port", self.preset.default_port)
             dashboard_enabled = self.answers.get("traefik_dashboard", True)
@@ -72,7 +72,7 @@ class TraefikStrategy(BaseStrategy):
 
         service["volumes"] = volumes
 
-        # --- Healthcheck через ping ---
+        # --- Healthcheck through ping ---
         service["healthcheck"] = {
             "test": ["CMD-SHELL", "wget -qO- http://localhost:8080/ping || exit 1"],
             "interval": "10s",

--- a/rdt/strategies/web_server.py
+++ b/rdt/strategies/web_server.py
@@ -1,11 +1,11 @@
 """
-WebServerStrategy — стратегия для веб-серверов (nginx, apache и подобных).
+WebServerStrategy — strategy for web servers such as nginx and apache.
 
-Особенности:
-- volumes как bind-mounts (не named volumes)
-- конфиг монтируется из локальной папки
-- для static/spa/php дополнительно монтируется директория с контентом
-- healthcheck через wget
+Features:
+- volumes are bind mounts instead of named volumes
+- config is mounted from a local directory
+- static/spa/php modes additionally mount a content directory
+- healthcheck uses wget
 """
 from __future__ import annotations
 
@@ -17,40 +17,40 @@ from rdt.strategies.base import BaseStrategy
 # Nginx
 # ---------------------------------------------------------------------------
 
-#: Nginx-режимы, которые требуют монтирования html-директории
+#: Nginx modes that require mounting an html directory.
 _HTML_MODES = {"nginx-static", "nginx-spa"}
 
-#: Дефолтная директория для конфига nginx (относительно cwd)
+#: Default nginx config directory relative to cwd.
 DEFAULT_CONFIG_DIR = "./nginx"
 
-#: Дефолтная директория для html (относительно cwd)
+#: Default html directory relative to cwd.
 DEFAULT_HTML_DIR = "./nginx/html"
 
 # ---------------------------------------------------------------------------
 # Apache
 # ---------------------------------------------------------------------------
 
-#: Apache-режимы (все пресеты на базе Apache)
+#: Apache modes (all Apache-based presets).
 _APACHE_MODES = {"apache-static", "apache-php"}
 
-#: Дефолтная директория для конфига Apache (относительно cwd)
+#: Default Apache config directory relative to cwd.
 DEFAULT_APACHE_CONFIG_DIR = "./apache"
 
-#: Дефолтная директория для html у apache-static (относительно cwd)
+#: Default html directory for apache-static relative to cwd.
 DEFAULT_APACHE_HTML_DIR = "./apache/html"
 
-#: Дефолтная директория исходников PHP-приложения (относительно cwd)
+#: Default PHP application source directory relative to cwd.
 DEFAULT_APACHE_SRC_DIR = "./src"
 
 
 class WebServerStrategy(BaseStrategy):
     """
-    Стратегия для веб-серверов (nginx и apache).
+    Strategy for web servers (nginx and apache).
 
-    Отличия от BaseStrategy:
-    - не использует named volumes — только bind-mounts
-    - маршрутизирует enrich-логику по семейству сервера
-    - добавляет healthcheck через wget
+    Differences from BaseStrategy:
+    - does not use named volumes, only bind mounts
+    - routes enrich logic by server family
+    - adds a wget-based healthcheck
     """
 
     def _enrich(self, service: dict[str, Any]) -> None:
@@ -59,7 +59,7 @@ class WebServerStrategy(BaseStrategy):
         else:
             self._enrich_nginx(service)
 
-        # Общий healthcheck для всех веб-серверов
+        # Shared healthcheck for all web servers.
         service["healthcheck"] = {
             "test": ["CMD-SHELL", "wget -qO /dev/null http://localhost/ || exit 1"],
             "interval": "10s",

--- a/rdt/wizard.py
+++ b/rdt/wizard.py
@@ -1,5 +1,5 @@
 """
-Интерактивный мастер добавления сервиса (Wizard Mode).
+Interactive service-addition wizard (Wizard Mode).
 """
 from __future__ import annotations
 from typing import Any, Callable
@@ -36,15 +36,15 @@ def run_wizard(
     services_with_healthcheck: set[str] | None = None,
 ) -> dict[str, Any]:
     """
-    Запустить интерактивный мастер для выбранного пресета.
-    Возвращает словарь answers для передачи в стратегию.
+    Run the interactive wizard for the selected preset.
+    Return an answers dictionary to pass into a strategy.
     """
     answers: dict[str, Any] = {}
     _svc_with_hc = services_with_healthcheck or set()
 
     console.print(t("wizard.configuring", name=preset.display_name))
 
-    # ── 1. Порт ──────────────────────────────────────────────────────────────
+    # ── 1. Port ──────────────────────────────────────────────────────────────
     answers["port"] = _ask_port(preset)
 
     # ── 2. Container name ────────────────────────────────────────────────────
@@ -60,22 +60,22 @@ def run_wizard(
     else:
         answers["use_default_creds"] = not hardcore
 
-    # ── 4. Volumes (только для БД) ────────────────────────────────────────────
+    # ── 4. Volumes (database services only) ──────────────────────────────────
     if preset.volumes and _needs_volume(preset):
         answers["volume_source"] = _ask_volume(preset)
 
-    # ── 5. Сеть ──────────────────────────────────────────────────────────────
+    # ── 5. Network ───────────────────────────────────────────────────────────
     net_type, net_name = _ask_network()
     answers["network_type"] = net_type
     answers["network_name"] = net_name
 
-    # ── 6. Прокидывание портов (не для host/none) ─────────────────────────────
+    # ── 6. Port publishing (not for host/none) ───────────────────────────────
     if net_type not in ("host", "none"):
         answers["expose_ports"] = _ask_expose_ports()
     else:
         answers["expose_ports"] = False
 
-    # ── 7. Healthcheck параметры ──────────────────────────────────────────────
+    # ── 7. Healthcheck parameters ────────────────────────────────────────────
     if preset.healthcheck:
         answers["healthcheck_params"] = _ask_healthcheck_params(preset)
 
@@ -90,7 +90,7 @@ def run_wizard(
     if candidates:
         answers = _ask_smart_mapping(preset.name, candidates, existing_services, answers)
 
-    # ── 10. Service-specific inputs (например, для nginx) ────────────────────
+    # ── 10. Service-specific inputs, for example nginx ──────────────────────
     extra_fn = _SERVICE_EXTRA_WIZARDS.get(preset.name)
     if extra_fn:
         answers = extra_fn(answers)
@@ -262,7 +262,7 @@ def _ask_smart_mapping(
     existing_services: list[str],
     answers: dict[str, Any],
 ) -> dict[str, Any]:
-    """Предложить выбрать родительский сервис для smart-mapping."""
+    """Offer parent service selection for smart mapping."""
     labels = {
         "pgadmin": "Postgres",
         "kafka-ui": "Kafka",
@@ -303,7 +303,7 @@ def _ask_smart_mapping(
 # ─────────────────────────────────────────────────────────────────────────────
 
 def _ask_nginx_proxy_inputs(answers: dict[str, Any]) -> dict[str, Any]:
-    """Дополнительные вопросы для nginx-proxy."""
+    """Ask additional questions for nginx-proxy."""
     console.print(t("wizard.nginx_specific_header"))
 
     upstream = questionary.text(
@@ -328,7 +328,7 @@ def _ask_nginx_proxy_inputs(answers: dict[str, Any]) -> dict[str, Any]:
 
 
 def _ask_nginx_html_inputs(answers: dict[str, Any]) -> dict[str, Any]:
-    """Дополнительные вопросы для nginx-static и nginx-spa."""
+    """Ask additional questions for nginx-static and nginx-spa."""
     console.print(t("wizard.nginx_specific_header"))
 
     server_name = questionary.text(
@@ -353,7 +353,7 @@ def _ask_nginx_html_inputs(answers: dict[str, Any]) -> dict[str, Any]:
 
 
 def _ask_apache_static_inputs(answers: dict[str, Any]) -> dict[str, Any]:
-    """Дополнительные вопросы для apache-static."""
+    """Ask additional questions for apache-static."""
     console.print(t("wizard.apache_specific_header"))
 
     server_name = questionary.text(
@@ -378,7 +378,7 @@ def _ask_apache_static_inputs(answers: dict[str, Any]) -> dict[str, Any]:
 
 
 def _ask_apache_php_inputs(answers: dict[str, Any]) -> dict[str, Any]:
-    """Дополнительные вопросы для apache-php."""
+    """Ask additional questions for apache-php."""
     console.print(t("wizard.apache_specific_header"))
 
     server_name = questionary.text(
@@ -403,10 +403,10 @@ def _ask_apache_php_inputs(answers: dict[str, Any]) -> dict[str, Any]:
 
 
 def _ask_logstash_inputs(answers: dict[str, Any]) -> dict[str, Any]:
-    """Дополнительные вопросы для Logstash: режим pipeline."""
+    """Ask additional questions for Logstash: pipeline mode."""
     console.print(t("wizard.logstash_specific_header"))
 
-    # Если smart mapping уже задал режим — предложить его как default
+    # If smart mapping already set the mode, offer it as the default.
     current_mode = answers.get("logstash_pipeline", "beats-stdout")
 
     mode = questionary.select(
@@ -430,7 +430,7 @@ def _ask_logstash_inputs(answers: dict[str, Any]) -> dict[str, Any]:
         ).ask()
         answers["logstash_es_host"] = (es_host or default_host).strip()
 
-    # Установить condition-флаги
+    # Set condition flags.
     answers["logstash_pipeline_stdout"] = (answers["logstash_pipeline"] == "beats-stdout")
     answers["logstash_pipeline_es"] = (answers["logstash_pipeline"] == "beats-es")
 
@@ -438,10 +438,10 @@ def _ask_logstash_inputs(answers: dict[str, Any]) -> dict[str, Any]:
 
 
 def _ask_filebeat_inputs(answers: dict[str, Any]) -> dict[str, Any]:
-    """Дополнительные вопросы для Filebeat: output mode, log path, optional Kibana host."""
+    """Ask additional questions for Filebeat: output mode, log path, optional Kibana host."""
     console.print(t("wizard.filebeat_specific_header"))
 
-    # Output mode — если smart mapping уже выбрал режим, предлагаем его как default
+    # Output mode: if smart mapping already selected a mode, offer it as the default.
     current_output = answers.get("filebeat_output", "stdout")
 
     output = questionary.select(
@@ -501,7 +501,7 @@ def _ask_filebeat_inputs(answers: dict[str, Any]) -> dict[str, Any]:
 
 
 def _ask_traefik_inputs(answers: dict[str, Any]) -> dict[str, Any]:
-    """Дополнительные вопросы для Traefik."""
+    """Ask additional questions for Traefik."""
     console.print(t("wizard.traefik_specific_header"))
 
     # Dashboard
@@ -572,8 +572,8 @@ def _ask_traefik_inputs(answers: dict[str, Any]) -> dict[str, Any]:
     return answers
 
 
-#: Маппинг service_name → callable для service-specific wizard вопросов.
-#: Расширяйте этот словарь при добавлении новых сервисов с конфигами.
+#: Mapping from service_name to callable for service-specific wizard questions.
+#: Extend this dictionary when adding new services with configs.
 _SERVICE_EXTRA_WIZARDS: dict[str, Callable[[dict[str, Any]], dict[str, Any]]] = {
     "nginx-proxy":   _ask_nginx_proxy_inputs,
     "nginx-static":  _ask_nginx_html_inputs,
@@ -587,13 +587,13 @@ _SERVICE_EXTRA_WIZARDS: dict[str, Callable[[dict[str, Any]], dict[str, Any]]] = 
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Главное интерактивное меню (запускается при rdt без аргументов)
+# Main interactive menu, started when rdt is run without arguments
 # ─────────────────────────────────────────────────────────────────────────────
 
 def run_main_menu() -> str:
     """
-    Показать главное интерактивное меню.
-    Возвращает строку-ключ выбранного действия.
+    Show the main interactive menu.
+    Return the selected action key.
     """
     console.print()
     console.print(Panel.fit(
@@ -626,8 +626,8 @@ def run_main_menu() -> str:
 
 def ask_service_choice() -> str | None:
     """
-    Показать каталог сервисов по категориям и вернуть выбранное имя сервиса
-    (или None если пользователь выбрал «Назад»).
+    Show the service catalog by category and return the selected service name,
+    or None when the user chooses Back.
     """
     from rdt.presets.catalog import ALL_PRESETS
 
@@ -657,8 +657,8 @@ def ask_service_choice() -> str | None:
 
 def ask_remove_service_choice(existing_services: list[str]) -> str | None:
     """
-    Показать список существующих сервисов и вернуть выбранный для удаления
-    (или None если пользователь выбрал «Назад»).
+    Show existing services and return the one selected for removal,
+    or None when the user chooses Back.
     """
     choices: list = []
     for svc in existing_services:
@@ -690,12 +690,12 @@ def build_script_answers(
     hc_start_period: str | None = None,
 ) -> dict[str, Any]:
     """
-    Сформировать словарь answers из CLI-флагов без интерактивного мастера.
-    Используется при запуске rdt add <service> --yes [--port X] [--volume Y] ...
+    Build an answers dictionary from CLI flags without the interactive wizard.
+    Used when running rdt add <service> --yes [--port X] [--volume Y] ...
     """
     answers: dict[str, Any] = {}
 
-    # Порт
+    # Port.
     answers["port"] = port if port is not None else preset.default_port
 
     # Container name
@@ -704,11 +704,11 @@ def build_script_answers(
     # Credentials
     answers["use_default_creds"] = not hardcore
 
-    # Volume (только для сервисов с volumes)
+    # Volume (only for services with volumes).
     if preset.volumes:
         answers["volume_source"] = volume if volume is not None else f"{preset.name}_data"
 
-    # Сеть
+    # Network.
     if network is None or network == "bridge":
         answers["network_type"] = "bridge"
         answers["network_name"] = NETWORK_NAME
@@ -719,14 +719,14 @@ def build_script_answers(
         answers["network_type"] = "none"
         answers["network_name"] = ""
     else:
-        # Имя external-сети
+        # External network name.
         answers["network_type"] = "external"
         answers["network_name"] = network
 
-    # Прокидывание портов
+    # Port publishing.
     answers["expose_ports"] = not no_ports
 
-    # Healthcheck параметры
+    # Healthcheck parameters.
     hc_params: dict[str, Any] = {}
     if hc_interval:
         hc_params["interval"] = hc_interval
@@ -738,16 +738,16 @@ def build_script_answers(
         hc_params["start_period"] = hc_start_period
     answers["healthcheck_params"] = hc_params
 
-    # Зависимости
+    # Dependencies.
     answers["depends_on"] = list(depends_on)
 
-    # Auto Smart Mapping — автоматически применяем первого найденного кандидата
+    # Auto Smart Mapping: automatically apply the first found candidate.
     candidates = get_candidate_parents(preset.name, existing_services)
     if candidates:
         answers["parent_service"] = candidates[0]
         answers = apply_smart_mapping(preset.name, existing_services, answers)
 
-    # Service-specific defaults для script mode
+    # Service-specific defaults for script mode.
     _apply_service_script_defaults(preset, answers)
 
     return answers
@@ -755,8 +755,8 @@ def build_script_answers(
 
 def _apply_service_script_defaults(preset: ServicePreset, answers: dict[str, Any]) -> None:
     """
-    Установить service-specific значения по умолчанию для script mode.
-    Вызывается из build_script_answers после всех общих параметров.
+    Set service-specific defaults for script mode.
+    Called from build_script_answers after all common parameters.
     """
     if preset.name == "nginx-proxy":
         answers.setdefault("nginx_upstream", "app:8000")
@@ -779,7 +779,7 @@ def _apply_service_script_defaults(preset: ServicePreset, answers: dict[str, Any
         answers.setdefault("apache_src_dir", DEFAULT_APACHE_SRC_DIR)
 
     elif preset.name == "logstash":
-        # Режим pipeline: если smart mapping нашёл ES — beats-es, иначе beats-stdout
+        # Pipeline mode: beats-es when smart mapping found ES, otherwise beats-stdout.
         pipeline = answers.get("logstash_pipeline", "beats-stdout")
         answers["logstash_pipeline"] = pipeline
         answers["logstash_pipeline_stdout"] = (pipeline == "beats-stdout")
@@ -791,7 +791,7 @@ def _apply_service_script_defaults(preset: ServicePreset, answers: dict[str, Any
             )
 
     elif preset.name == "filebeat":
-        # Output mode: если smart mapping нашёл Logstash — logstash, нашёл ES — elasticsearch, иначе stdout
+        # Output mode: logstash when found, otherwise elasticsearch when ES is found, otherwise stdout.
         output = answers.get("filebeat_output", "stdout")
         answers["filebeat_output"] = output
         answers["filebeat_output_logstash"] = (output == "logstash")

--- a/rdt/yaml_manager.py
+++ b/rdt/yaml_manager.py
@@ -1,6 +1,6 @@
 """
-Чтение и запись docker-compose.yml через ruamel.yaml
-(сохраняет комментарии, порядок ключей, форматирование).
+Read and write docker-compose.yml through ruamel.yaml.
+Preserves comments, key order, and formatting.
 """
 from __future__ import annotations
 from pathlib import Path
@@ -10,6 +10,14 @@ from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
 from rdt.strategies.base import NETWORK_NAME
+
+DEFAULT_COMPOSE_FILE = "docker-compose.yml"
+COMMON_COMPOSE_FILENAMES = (
+    "compose.yml",
+    "compose.yaml",
+    "docker-compose.yaml",
+    DEFAULT_COMPOSE_FILE,
+)
 
 _yaml = YAML()
 _yaml.default_flow_style = False
@@ -26,8 +34,25 @@ def _make_yaml() -> YAML:
     return y
 
 
+def find_existing_compose_file(project_dir: Path | None = None) -> Path | None:
+    """Return the first existing Compose file matching common naming conventions."""
+    base = project_dir or Path.cwd()
+    for filename in COMMON_COMPOSE_FILENAMES:
+        candidate = base / filename
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def resolve_default_compose_file(file: Path) -> Path:
+    """Resolve the default compose path to an existing common Compose filename."""
+    if file.exists() or file.name != DEFAULT_COMPOSE_FILE:
+        return file
+    return find_existing_compose_file(file.parent) or file
+
+
 def load_compose(path: Path) -> CommentedMap:
-    """Загрузить docker-compose.yml; вернуть пустую структуру если файла нет."""
+    """Load docker-compose.yml; return an empty structure when the file is missing."""
     y = _make_yaml()
     if path.exists():
         with path.open("r", encoding="utf-8") as f:
@@ -39,23 +64,23 @@ def load_compose(path: Path) -> CommentedMap:
 
 
 def save_compose(path: Path, data: CommentedMap) -> None:
-    """Сохранить docker-compose.yml. Создаёт родительскую директорию при необходимости."""
+    """Save docker-compose.yml and create the parent directory when needed."""
     import re
     import io
-    # Гарантировать существование родительской директории (для --file infra/docker-compose.yml)
+    # Ensure the parent directory exists for --file infra/docker-compose.yml.
     path.parent.mkdir(parents=True, exist_ok=True)
     _normalize_healthcheck_test_flow_style(data)
     y = _make_yaml()
     buf = io.StringIO()
     y.dump(data, buf)
-    # Нормализуем накопившиеся пустые строки: ≥3 переноса → ровно 2 (= 1 пустая строка)
+    # Normalize accumulated blank lines: ≥3 newlines → exactly 2 (= one blank line).
     content = re.sub(r'\n{3,}', '\n\n', buf.getvalue())
     with path.open("w", encoding="utf-8") as f:
         f.write(content)
 
 
 def make_base_compose(network_config: dict | None = None) -> CommentedMap:
-    """Создать базовую структуру docker-compose.yml.
+    """Create the base docker-compose.yml structure.
 
     network_config: {"type": "bridge"|"external"|"host"|"none", "name": str}
     """
@@ -82,7 +107,7 @@ def inject_service(
     service_def: dict[str, Any],
     network_config: dict | None = None,
 ) -> CommentedMap:
-    """Вставить новый сервис в секцию services без нарушения структуры.
+    """Insert a new service into the services section without breaking structure.
 
     network_config: {"type": "bridge"|"external"|"host"|"none", "name": str}
     """
@@ -94,7 +119,7 @@ def inject_service(
     net_type = (network_config or {}).get("type", "bridge")
     net_name = (network_config or {}).get("name", NETWORK_NAME)
 
-    # Управление секцией networks в зависимости от типа
+    # Manage the networks section depending on the network type.
     if net_type in ("bridge", "external"):
         if "networks" not in data:
             data["networks"] = CommentedMap()
@@ -103,46 +128,46 @@ def inject_service(
                 data["networks"][net_name] = CommentedMap({"driver": "bridge"})
             else:
                 data["networks"][net_name] = CommentedMap({"external": True})
-    # host / none — секция networks для этой сети не нужна
+    # host / none do not need a networks section for this network.
 
-    # Конвертируем в CommentedMap для сохранения порядка
+    # Convert to CommentedMap to preserve order.
     svc_map = _dict_to_commented(service_def)
     data["services"][service_name] = svc_map
 
-    # Пустая строка перед каждым сервисом кроме первого
+    # Add a blank line before each service except the first.
     if len(data["services"]) > 1:
         data["services"].yaml_set_comment_before_after_key(service_name, before="\n")
 
-    # Регистрируем named volumes
+    # Register named volumes.
     for vol in service_def.get("volumes", []):
         vol_str = str(vol)
         if ":" in vol_str:
             source = vol_str.split(":")[0]
-            # Именованный volume — не начинается с . или /
+            # Named volumes do not start with . or /.
             if not source.startswith(".") and not source.startswith("/"):
                 if source not in data["volumes"]:
                     data["volumes"][source] = None  # type: ignore[assignment]
 
-    # Пустая строка перед networks и volumes (верхний уровень)
+    # Blank line before top-level networks and volumes.
     _ensure_section_spacing(data)
 
     return data
 
 
 def _ensure_section_spacing(data: CommentedMap) -> None:
-    """Гарантировать пустую строку перед networks и volumes на верхнем уровне."""
+    """Ensure a blank line before top-level networks and volumes."""
     for key in ("networks", "volumes"):
         if key in data:
             data.yaml_set_comment_before_after_key(key, before="\n")
 
 
 def get_existing_services(data: CommentedMap) -> list[str]:
-    """Вернуть список имён сервисов из docker-compose."""
+    """Return service names from docker-compose."""
     return list(data.get("services", {}).keys())
 
 
 def get_dependents(data: CommentedMap, service_name: str) -> list[str]:
-    """Вернуть список сервисов, которые зависят от service_name через depends_on."""
+    """Return services that depend on service_name through depends_on."""
     result: list[str] = []
     for svc_name, svc_def in (data.get("services") or {}).items():
         if svc_name == service_name:
@@ -156,7 +181,7 @@ def get_dependents(data: CommentedMap, service_name: str) -> list[str]:
 
 
 def get_service_named_volumes(data: CommentedMap, service_name: str) -> set[str]:
-    """Вернуть именованные volumes (не bind-mount), используемые указанным сервисом."""
+    """Return named volumes, not bind mounts, used by the specified service."""
     result: set[str] = set()
     svc_def = (data.get("services") or {}).get(service_name) or {}
     for vol in svc_def.get("volumes", []):
@@ -169,21 +194,21 @@ def get_service_named_volumes(data: CommentedMap, service_name: str) -> set[str]
 
 
 def remove_service(data: CommentedMap, service_name: str) -> tuple[CommentedMap, list[str]]:
-    """Удалить сервис из compose-данных.
+    """Remove a service from compose data.
 
-    Возвращает (обновлённые данные, список удалённых named volumes).
-    Named volume удаляется только если больше не используется другими сервисами.
+    Returns updated data and a list of removed named volumes.
+    A named volume is removed only when no other service uses it.
     """
     if "services" not in data or service_name not in data["services"]:
         return data, []
 
-    # Запомнить именованные volumes удаляемого сервиса
+    # Remember named volumes used by the removed service.
     service_volumes = get_service_named_volumes(data, service_name)
 
-    # Удалить сервис
+    # Remove the service.
     del data["services"][service_name]
 
-    # Найти volumes, всё ещё используемые оставшимися сервисами
+    # Find volumes that are still used by remaining services.
     still_used: set[str] = set()
     for _, svc_def in (data.get("services") or {}).items():
         for vol in (svc_def or {}).get("volumes", []):
@@ -193,7 +218,7 @@ def remove_service(data: CommentedMap, service_name: str) -> tuple[CommentedMap,
                 if not source.startswith(".") and not source.startswith("/"):
                     still_used.add(source)
 
-    # Удалить осиротевшие named volumes из секции volumes
+    # Remove orphaned named volumes from the volumes section.
     removed_volumes: list[str] = []
     for vol_name in service_volumes:
         if vol_name not in still_used:
@@ -205,7 +230,7 @@ def remove_service(data: CommentedMap, service_name: str) -> tuple[CommentedMap,
 
 
 def get_services_with_healthcheck(data: CommentedMap) -> set[str]:
-    """Вернуть множество имён сервисов, у которых задан healthcheck."""
+    """Return service names that define a healthcheck."""
     result: set[str] = set()
     for svc_name, svc_def in (data.get("services") or {}).items():
         if svc_def and "healthcheck" in svc_def:
@@ -214,7 +239,7 @@ def get_services_with_healthcheck(data: CommentedMap) -> set[str]:
 
 
 def _normalize_healthcheck_test_flow_style(d: Any, path: tuple[str, ...] = ()) -> Any:
-    """Принудительно записывать все healthcheck.test списки в inline (flow) стиле."""
+    """Force all healthcheck.test lists to use inline flow style."""
     if isinstance(d, dict):
         for k, v in list(d.items()):
             child_path = path + (str(k),)
@@ -233,10 +258,10 @@ def _normalize_healthcheck_test_flow_style(d: Any, path: tuple[str, ...] = ()) -
 
 
 def _dict_to_commented(d: Any, path: tuple[str, ...] = ()) -> Any:
-    """Рекурсивно конвертировать dict → CommentedMap, list → CommentedSeq.
+    """Recursively convert dict → CommentedMap and list → CommentedSeq.
 
-    Списки healthcheck.test сериализуются в inline (flow) стиле,
-    т.к. Docker Compose ожидает test: ["CMD-SHELL", "..."] или ["CMD", "..."].
+    healthcheck.test lists are serialized in inline flow style because
+    Docker Compose expects test: ["CMD-SHELL", "..."] or ["CMD", "..."].
     """
     if isinstance(d, dict):
         cm = CommentedMap()

--- a/tests/test_artifact_pipeline.py
+++ b/tests/test_artifact_pipeline.py
@@ -1,21 +1,21 @@
 """
-Smoke / functional tests для ArtifactPipeline (core-hardening M1–M3).
+Smoke / functional tests for ArtifactPipeline (core-hardening M1-M3).
 
-Покрывают:
-- успешную генерацию nginx-proxy, nginx-static, nginx-spa (TEMPLATE)
-- ArtifactSourceType.STATIC и ArtifactSourceType.PYTHON
+Covers:
+- successful generation for nginx-proxy, nginx-static, nginx-spa (TEMPLATE)
+- ArtifactSourceType.STATIC and ArtifactSourceType.PYTHON
 - ArtifactContext.as_template_vars()
-- политику SKIP (существующий файл не перезаписывается)
-- политику OVERWRITE (существующий файл перезаписывается)
-- политику ERROR_IF_EXISTS (ошибка если файл уже существует)
-- preflight: обнаружение отсутствующего шаблона
-- preflight: обнаружение конфликта ERROR_IF_EXISTS
-- preflight: обнаружение STATIC без static_content
-- preflight: обнаружение PYTHON без renderer
-- preflight: успешный проход без проблем
+- SKIP policy (existing file is not overwritten)
+- OVERWRITE policy (existing file is overwritten)
+- ERROR_IF_EXISTS policy (error when the file already exists)
+- preflight: missing template detection
+- preflight: ERROR_IF_EXISTS conflict detection
+- preflight: STATIC without static_content detection
+- preflight: PYTHON without renderer detection
+- preflight: successful pass without issues
 - has_errors() helper
-- корректную работу с нестандартным project_root (аналог --file)
-- падение при ошибке шаблона (несуществующий шаблон)
+- correct behavior with non-standard project_root (similar to --file)
+- failure on template error (missing template)
 - plan→apply split
 """
 from __future__ import annotations
@@ -35,7 +35,7 @@ from rdt.artifacts import (
 
 
 # ---------------------------------------------------------------------------
-# Хелперы
+# Helpers
 # ---------------------------------------------------------------------------
 
 NGINX_ANSWERS = {
@@ -73,11 +73,11 @@ def _make_pipeline(
 
 
 # ---------------------------------------------------------------------------
-# Успешная генерация
+# Successful generation
 # ---------------------------------------------------------------------------
 
 def test_nginx_proxy_created(tmp_path: Path) -> None:
-    """Pipeline создаёт nginx/nginx.conf для nginx-proxy."""
+    """Pipeline creates nginx/nginx.conf for nginx-proxy."""
     artifact = ArtifactDef(
         relative_path="nginx/nginx.conf",
         source_template="nginx/nginx-proxy.conf.j2",
@@ -95,7 +95,7 @@ def test_nginx_proxy_created(tmp_path: Path) -> None:
 
 
 def test_nginx_static_created(tmp_path: Path) -> None:
-    """Pipeline создаёт nginx/nginx.conf для nginx-static."""
+    """Pipeline creates nginx/nginx.conf for nginx-static."""
     artifact = ArtifactDef(
         relative_path="nginx/nginx.conf",
         source_template="nginx/nginx-static.conf.j2",
@@ -106,7 +106,7 @@ def test_nginx_static_created(tmp_path: Path) -> None:
 
 
 def test_nginx_spa_created(tmp_path: Path) -> None:
-    """Pipeline создаёт nginx/nginx.conf для nginx-spa."""
+    """Pipeline creates nginx/nginx.conf for nginx-spa."""
     artifact = ArtifactDef(
         relative_path="nginx/nginx.conf",
         source_template="nginx/nginx-spa.conf.j2",
@@ -117,11 +117,11 @@ def test_nginx_spa_created(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Политики перезаписи
+# Overwrite policies
 # ---------------------------------------------------------------------------
 
 def test_skip_existing_file(tmp_path: Path) -> None:
-    """SKIP: существующий файл не перезаписывается."""
+    """SKIP: an existing file is not overwritten."""
     target = tmp_path / "nginx" / "nginx.conf"
     target.parent.mkdir(parents=True)
     target.write_text("ORIGINAL", encoding="utf-8")
@@ -138,7 +138,7 @@ def test_skip_existing_file(tmp_path: Path) -> None:
 
 
 def test_overwrite_existing_file(tmp_path: Path) -> None:
-    """OVERWRITE: существующий файл перезаписывается."""
+    """OVERWRITE: an existing file is overwritten."""
     target = tmp_path / "nginx" / "nginx.conf"
     target.parent.mkdir(parents=True)
     target.write_text("ORIGINAL", encoding="utf-8")
@@ -155,7 +155,7 @@ def test_overwrite_existing_file(tmp_path: Path) -> None:
 
 
 def test_error_if_exists_policy(tmp_path: Path) -> None:
-    """ERROR_IF_EXISTS: возвращает ошибку если файл уже существует."""
+    """ERROR_IF_EXISTS: returns an error when the file already exists."""
     target = tmp_path / "nginx" / "nginx.conf"
     target.parent.mkdir(parents=True)
     target.write_text("ORIGINAL", encoding="utf-8")
@@ -169,7 +169,7 @@ def test_error_if_exists_policy(tmp_path: Path) -> None:
 
     assert results[0].status == "error"
     assert results[0].error is not None
-    # Файл не должен быть изменён
+    # The file must not be changed.
     assert target.read_text() == "ORIGINAL"
 
 
@@ -180,7 +180,7 @@ def test_error_if_exists_policy(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 def test_preflight_ok(tmp_path: Path) -> None:
-    """Preflight не возвращает проблем для валидного артефакта."""
+    """Preflight returns no issues for a valid artifact."""
     artifact = ArtifactDef(
         relative_path="nginx/nginx.conf",
         source_template="nginx/nginx-proxy.conf.j2",
@@ -191,7 +191,7 @@ def test_preflight_ok(tmp_path: Path) -> None:
 
 
 def test_preflight_catches_missing_template(tmp_path: Path) -> None:
-    """Preflight обнаруживает отсутствующий шаблон."""
+    """Preflight detects a missing template."""
     artifact = ArtifactDef(
         relative_path="nginx/nginx.conf",
         source_template="nginx/DOES_NOT_EXIST.conf.j2",
@@ -203,7 +203,7 @@ def test_preflight_catches_missing_template(tmp_path: Path) -> None:
 
 
 def test_preflight_catches_error_if_exists(tmp_path: Path) -> None:
-    """Preflight обнаруживает ERROR_IF_EXISTS конфликт до записи."""
+    """Preflight detects an ERROR_IF_EXISTS conflict before writing."""
     target = tmp_path / "nginx" / "nginx.conf"
     target.parent.mkdir(parents=True)
     target.write_text("EXISTS", encoding="utf-8")
@@ -219,23 +219,23 @@ def test_preflight_catches_error_if_exists(tmp_path: Path) -> None:
 
 
 def test_preflight_skips_inactive_conditions(tmp_path: Path) -> None:
-    """Preflight пропускает артефакты с невыполненным условием."""
+    """Preflight skips artifacts whose condition is not met."""
     artifact = ArtifactDef(
         relative_path="nginx/nginx.conf",
         source_template="nginx/DOES_NOT_EXIST.conf.j2",
-        condition="generate_nginx",  # ключ отсутствует в answers
+        condition="generate_nginx",  # key is missing from answers
     )
     pipeline = _make_pipeline([artifact], tmp_path)
     issues = pipeline.preflight()
-    assert issues == []  # условие не выполнено → артефакт неактивен, проблем нет
+    assert issues == []  # condition is not met → artifact is inactive, no issues
 
 
 # ---------------------------------------------------------------------------
-# Падение при ошибке шаблона
+# Failure on template error
 # ---------------------------------------------------------------------------
 
 def test_missing_template_returns_error(tmp_path: Path) -> None:
-    """Несуществующий шаблон → статус 'error', не исключение."""
+    """Missing template → status 'error', not an exception."""
     artifact = ArtifactDef(
         relative_path="nginx/nginx.conf",
         source_template="nginx/DOES_NOT_EXIST.conf.j2",
@@ -250,7 +250,7 @@ def test_missing_template_returns_error(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 def test_has_errors_true() -> None:
-    """has_errors возвращает True если есть хотя бы одна ошибка."""
+    """has_errors returns True when there is at least one error."""
     results = [
         ArtifactResult(path=Path("a"), status="created"),
         ArtifactResult(path=Path("b"), status="error", error="oops"),
@@ -259,7 +259,7 @@ def test_has_errors_true() -> None:
 
 
 def test_has_errors_false() -> None:
-    """has_errors возвращает False если нет ошибок."""
+    """has_errors returns False when there are no errors."""
     results = [
         ArtifactResult(path=Path("a"), status="created"),
         ArtifactResult(path=Path("b"), status="skipped"),
@@ -268,11 +268,11 @@ def test_has_errors_false() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Работа с нестандартным base_dir (аналог --file)
+# Behavior with non-standard base_dir (similar to --file)
 # ---------------------------------------------------------------------------
 
 def test_custom_base_dir(tmp_path: Path) -> None:
-    """Артефакты генерируются относительно переданного base_dir."""
+    """Artifacts are generated relative to the provided base_dir."""
     custom_root = tmp_path / "infra"
     custom_root.mkdir()
 
@@ -285,27 +285,73 @@ def test_custom_base_dir(tmp_path: Path) -> None:
     assert results[0].status == "created"
     expected = custom_root / "nginx" / "nginx.conf"
     assert expected.exists()
-    # Файл не должен появиться в tmp_path напрямую
+    # The file must not appear directly under tmp_path.
     assert not (tmp_path / "nginx" / "nginx.conf").exists()
 
 
 # ---------------------------------------------------------------------------
-# Тест _resolve_project_root из cli
+# Test _resolve_project_root from cli
 # ---------------------------------------------------------------------------
 
 def test_resolve_project_root_default() -> None:
-    """Для docker-compose.yml в cwd root == cwd."""
+    """For docker-compose.yml in cwd, root == cwd."""
     from rdt.cli import _resolve_project_root
     result = _resolve_project_root(Path("docker-compose.yml"))
     assert result == Path.cwd().resolve()
 
 
 def test_resolve_project_root_subdir(tmp_path: Path) -> None:
-    """Для файла в поддиректории root == поддиректория."""
+    """For a file in a subdirectory, root == that subdirectory."""
     from rdt.cli import _resolve_project_root
     compose = tmp_path / "infra" / "docker-compose.yml"
     result = _resolve_project_root(compose)
     assert result == (tmp_path / "infra").resolve()
+
+
+def test_find_existing_compose_file_prefers_common_order(tmp_path: Path) -> None:
+    """Existing Compose files are detected using common filename conventions."""
+    from rdt.yaml_manager import find_existing_compose_file
+
+    (tmp_path / "docker-compose.yaml").write_text("services: {}\n", encoding="utf-8")
+    (tmp_path / "compose.yml").write_text("services: {}\n", encoding="utf-8")
+
+    assert find_existing_compose_file(tmp_path) == tmp_path / "compose.yml"
+
+
+def test_resolve_default_compose_file_uses_existing_compose_yaml(tmp_path: Path) -> None:
+    """The default docker-compose.yml path resolves to an existing compose.yaml."""
+    from rdt.yaml_manager import resolve_default_compose_file
+
+    existing = tmp_path / "compose.yaml"
+    existing.write_text("services: {}\n", encoding="utf-8")
+
+    assert resolve_default_compose_file(tmp_path / "docker-compose.yml") == existing
+
+
+def test_resolve_default_compose_file_keeps_custom_path(tmp_path: Path) -> None:
+    """Custom compose paths are not replaced by common filename discovery."""
+    from rdt.yaml_manager import resolve_default_compose_file
+
+    (tmp_path / "compose.yml").write_text("services: {}\n", encoding="utf-8")
+    custom = tmp_path / "custom-compose.yml"
+
+    assert resolve_default_compose_file(custom) == custom
+
+
+def test_cli_add_uses_existing_compose_yml_by_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """rdt add --yes updates compose.yml instead of creating docker-compose.yml."""
+    from typer.testing import CliRunner
+    from rdt.cli import app
+
+    monkeypatch.chdir(tmp_path)
+    compose = tmp_path / "compose.yml"
+    compose.write_text("services: {}\n", encoding="utf-8")
+
+    result = CliRunner().invoke(app, ["add", "redis", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert "redis:" in compose.read_text(encoding="utf-8")
+    assert not (tmp_path / "docker-compose.yml").exists()
 
 
 
@@ -314,7 +360,7 @@ def test_resolve_project_root_subdir(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 def test_artifact_context_as_template_vars(tmp_path: Path) -> None:
-    """as_template_vars() включает answers + служебные поля."""
+    """as_template_vars() includes answers plus service fields."""
     ctx = ArtifactContext(
         service_name="my-svc",
         answers={"foo": "bar"},
@@ -331,7 +377,7 @@ def test_artifact_context_as_template_vars(tmp_path: Path) -> None:
 
 
 def test_artifact_context_with_preset(tmp_path: Path) -> None:
-    """as_template_vars() включает preset_name и preset_display_name если preset задан."""
+    """as_template_vars() includes preset_name and preset_display_name when preset is set."""
     class _FakePreset:
         name = "nginx-proxy"
         display_name = "Nginx Proxy"
@@ -354,7 +400,7 @@ def test_artifact_context_with_preset(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 def test_static_source_creates_file(tmp_path: Path) -> None:
-    """STATIC: записывает static_content в целевой файл."""
+    """STATIC: writes static_content to the target file."""
     artifact = ArtifactDef(
         relative_path="config/app.conf",
         source_type=ArtifactSourceType.STATIC,
@@ -367,7 +413,7 @@ def test_static_source_creates_file(tmp_path: Path) -> None:
 
 
 def test_preflight_catches_static_without_content(tmp_path: Path) -> None:
-    """Preflight обнаруживает STATIC без static_content."""
+    """Preflight detects STATIC without static_content."""
     artifact = ArtifactDef(
         relative_path="config/app.conf",
         source_type=ArtifactSourceType.STATIC,
@@ -383,7 +429,7 @@ def test_preflight_catches_static_without_content(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 def test_python_source_creates_file(tmp_path: Path) -> None:
-    """PYTHON: вызывает renderer(context) и записывает результат."""
+    """PYTHON: calls renderer(context) and writes the result."""
     def my_renderer(ctx: ArtifactContext) -> str:
         return f"# Generated for {ctx.service_name}\nupstream={ctx.answers.get('nginx_upstream')}\n"
 
@@ -400,7 +446,7 @@ def test_python_source_creates_file(tmp_path: Path) -> None:
 
 
 def test_preflight_catches_python_without_renderer(tmp_path: Path) -> None:
-    """Preflight обнаруживает PYTHON без renderer."""
+    """Preflight detects PYTHON without renderer."""
     artifact = ArtifactDef(
         relative_path="config/dynamic.conf",
         source_type=ArtifactSourceType.PYTHON,
@@ -416,7 +462,7 @@ def test_preflight_catches_python_without_renderer(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 def test_plan_returns_create_for_new_file(tmp_path: Path) -> None:
-    """plan() возвращает action='create' для нового файла."""
+    """plan() returns action='create' for a new file."""
     artifact = ArtifactDef(
         relative_path="nginx/nginx.conf",
         source_template="nginx/nginx-proxy.conf.j2",
@@ -428,7 +474,7 @@ def test_plan_returns_create_for_new_file(tmp_path: Path) -> None:
 
 
 def test_plan_returns_skip_for_existing_file(tmp_path: Path) -> None:
-    """plan() возвращает action='skip' для существующего файла с политикой SKIP."""
+    """plan() returns action='skip' for an existing file with SKIP policy."""
     target = tmp_path / "nginx" / "nginx.conf"
     target.parent.mkdir(parents=True)
     target.write_text("EXISTS")
@@ -443,7 +489,7 @@ def test_plan_returns_skip_for_existing_file(tmp_path: Path) -> None:
 
 
 def test_plan_returns_overwrite_for_existing_file(tmp_path: Path) -> None:
-    """plan() возвращает action='overwrite' для существующего файла с политикой OVERWRITE."""
+    """plan() returns action='overwrite' for an existing file with OVERWRITE policy."""
     target = tmp_path / "nginx" / "nginx.conf"
     target.parent.mkdir(parents=True)
     target.write_text("EXISTS")
@@ -458,7 +504,7 @@ def test_plan_returns_overwrite_for_existing_file(tmp_path: Path) -> None:
 
 
 def test_apply_executes_plan(tmp_path: Path) -> None:
-    """apply(plan()) эквивалентен run() — файл создаётся."""
+    """apply(plan()) is equivalent to run(); the file is created."""
     artifact = ArtifactDef(
         relative_path="nginx/nginx.conf",
         source_template="nginx/nginx-proxy.conf.j2",
@@ -471,11 +517,11 @@ def test_apply_executes_plan(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# --set parsing (unit test — без запуска CLI)
+# --set parsing (unit test without starting the CLI)
 # ---------------------------------------------------------------------------
 
 def test_set_overrides_applied_to_answers(tmp_path: Path) -> None:
-    """--set переопределяет ответ мастера в шаблоне."""
+    """--set overrides the wizard answer in the template."""
     overridden_answers = {**NGINX_ANSWERS, "nginx_upstream": "custom-app:9999"}
     artifact = ArtifactDef(
         relative_path="nginx/nginx.conf",
@@ -488,11 +534,11 @@ def test_set_overrides_applied_to_answers(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# ArtifactContext — новые поля (smart_env, depends_on, parent_service, service_def)
+# ArtifactContext — new fields (smart_env, depends_on, parent_service, service_def)
 # ---------------------------------------------------------------------------
 
 def test_artifact_context_new_fields_in_template_vars(tmp_path: Path) -> None:
-    """as_template_vars() включает smart_env, depends_on, parent_service."""
+    """as_template_vars() includes smart_env, depends_on, parent_service."""
     ctx = ArtifactContext(
         service_name="logstash",
         answers={},
@@ -513,7 +559,7 @@ def test_artifact_context_new_fields_in_template_vars(tmp_path: Path) -> None:
 
 
 def test_artifact_context_defaults_for_new_fields(tmp_path: Path) -> None:
-    """Новые поля имеют безопасные defaults (пустые коллекции / None)."""
+    """New fields have safe defaults (empty collections / None)."""
     ctx = ArtifactContext(
         service_name="svc",
         answers={},
@@ -532,7 +578,7 @@ def test_artifact_context_defaults_for_new_fields(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Logstash — шаблоны
+# Logstash — templates
 # ---------------------------------------------------------------------------
 
 LOGSTASH_ANSWERS_STDOUT = {
@@ -565,7 +611,7 @@ def _make_logstash_context(base_dir: Path, answers: dict) -> ArtifactContext:
 
 
 def test_logstash_beats_stdout_created(tmp_path: Path) -> None:
-    """Logstash beats-stdout pipeline config создаётся когда условие выполнено."""
+    """Logstash beats-stdout pipeline config is created when the condition is met."""
     artifact = ArtifactDef(
         relative_path="logstash/pipeline/logstash.conf",
         source_template="logstash/logstash-beats-stdout.conf.j2",
@@ -585,7 +631,7 @@ def test_logstash_beats_stdout_created(tmp_path: Path) -> None:
 
 
 def test_logstash_beats_stdout_skipped_when_es_mode(tmp_path: Path) -> None:
-    """Logstash beats-stdout артефакт неактивен когда выбран режим beats-es."""
+    """Logstash beats-stdout artifact is inactive when beats-es mode is selected."""
     artifact = ArtifactDef(
         relative_path="logstash/pipeline/logstash.conf",
         source_template="logstash/logstash-beats-stdout.conf.j2",
@@ -594,12 +640,12 @@ def test_logstash_beats_stdout_skipped_when_es_mode(tmp_path: Path) -> None:
     ctx = _make_logstash_context(tmp_path, LOGSTASH_ANSWERS_ES)
     pipeline = ArtifactPipeline([artifact], ctx)
     plans = pipeline.plan()
-    # Условие не выполнено → артефакт не включён в план
+    # Condition is not met → artifact is not included in the plan.
     assert len(plans) == 0
 
 
 def test_logstash_beats_es_created(tmp_path: Path) -> None:
-    """Logstash beats-es pipeline config создаётся с правильным ES host."""
+    """Logstash beats-es pipeline config is created with the correct ES host."""
     artifact = ArtifactDef(
         relative_path="logstash/pipeline/logstash.conf",
         source_template="logstash/logstash-beats-es.conf.j2",
@@ -618,7 +664,7 @@ def test_logstash_beats_es_created(tmp_path: Path) -> None:
 
 
 def test_logstash_beats_es_uses_smart_env_host(tmp_path: Path) -> None:
-    """ES host берётся из smart_env если logstash_es_host не задан явно."""
+    """ES host is taken from smart_env when logstash_es_host is not set explicitly."""
     answers = {
         "logstash_pipeline": "beats-es",
         "logstash_pipeline_stdout": False,
@@ -640,7 +686,7 @@ def test_logstash_beats_es_uses_smart_env_host(tmp_path: Path) -> None:
 
 
 def test_logstash_yml_always_created(tmp_path: Path) -> None:
-    """logstash.yml создаётся всегда (нет условия)."""
+    """logstash.yml is always created (no condition)."""
     artifact = ArtifactDef(
         relative_path="logstash/config/logstash.yml",
         source_template="logstash/logstash.yml.j2",
@@ -656,7 +702,7 @@ def test_logstash_yml_always_created(tmp_path: Path) -> None:
 
 
 def test_logstash_conditional_only_one_pipeline_active(tmp_path: Path) -> None:
-    """Из двух conditional артефактов активен ровно один."""
+    """Exactly one of two conditional artifacts is active."""
     artifacts = [
         ArtifactDef(
             relative_path="logstash/pipeline/logstash.conf",
@@ -673,7 +719,7 @@ def test_logstash_conditional_only_one_pipeline_active(tmp_path: Path) -> None:
             source_template="logstash/logstash.yml.j2",
         ),
     ]
-    # Режим beats-es: активны только beats-es + logstash.yml
+    # beats-es mode: only beats-es + logstash.yml are active.
     ctx = _make_logstash_context(tmp_path, LOGSTASH_ANSWERS_ES)
     pipeline = ArtifactPipeline(artifacts, ctx)
     plans = pipeline.plan()
@@ -689,7 +735,7 @@ def test_logstash_conditional_only_one_pipeline_active(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 def test_logstash_smart_mapping_detects_elasticsearch() -> None:
-    """_logstash_mapping устанавливает ES_HOST и depends_on при наличии elasticsearch."""
+    """_logstash_mapping sets ES_HOST and depends_on when elasticsearch exists."""
     from rdt.smart_mapping import apply_smart_mapping
     answers: dict = {}
     result = apply_smart_mapping("logstash", ["elasticsearch", "redis"], answers)
@@ -700,7 +746,7 @@ def test_logstash_smart_mapping_detects_elasticsearch() -> None:
 
 
 def test_logstash_smart_mapping_detects_opensearch() -> None:
-    """_logstash_mapping работает и с opensearch."""
+    """_logstash_mapping also works with opensearch."""
     from rdt.smart_mapping import apply_smart_mapping
     answers: dict = {}
     result = apply_smart_mapping("logstash", ["opensearch"], answers)
@@ -709,7 +755,7 @@ def test_logstash_smart_mapping_detects_opensearch() -> None:
 
 
 def test_logstash_smart_mapping_noop_without_es() -> None:
-    """_logstash_mapping не изменяет answers если ES/OpenSearch не найден."""
+    """_logstash_mapping does not change answers when ES/OpenSearch is missing."""
     from rdt.smart_mapping import apply_smart_mapping
     answers: dict = {}
     result = apply_smart_mapping("logstash", ["redis", "postgres"], answers)
@@ -718,7 +764,7 @@ def test_logstash_smart_mapping_noop_without_es() -> None:
 
 
 def test_logstash_get_candidate_parents() -> None:
-    """get_candidate_parents возвращает ES/OpenSearch сервисы для logstash."""
+    """get_candidate_parents returns ES/OpenSearch services for logstash."""
     from rdt.smart_mapping import get_candidate_parents
     candidates = get_candidate_parents("logstash", ["elasticsearch", "redis", "opensearch"])
     assert "elasticsearch" in candidates
@@ -731,7 +777,7 @@ def test_logstash_get_candidate_parents() -> None:
 # ---------------------------------------------------------------------------
 
 def test_scaffold_plan_create_for_new_dir(tmp_path: Path) -> None:
-    """ScaffoldPipeline.plan() возвращает 'create' для несуществующей директории."""
+    """ScaffoldPipeline.plan() returns 'create' for a missing directory."""
     from rdt.artifacts import DirectoryDef, ScaffoldPipeline
     dirs = [DirectoryDef(relative_path="logstash/pipeline")]
     sp = ScaffoldPipeline(dirs, tmp_path)
@@ -742,7 +788,7 @@ def test_scaffold_plan_create_for_new_dir(tmp_path: Path) -> None:
 
 
 def test_scaffold_plan_skip_for_existing_dir(tmp_path: Path) -> None:
-    """ScaffoldPipeline.plan() возвращает 'skip' для уже существующей директории."""
+    """ScaffoldPipeline.plan() returns 'skip' for an existing directory."""
     from rdt.artifacts import DirectoryDef, ScaffoldPipeline
     existing = tmp_path / "data"
     existing.mkdir()
@@ -754,7 +800,7 @@ def test_scaffold_plan_skip_for_existing_dir(tmp_path: Path) -> None:
 
 
 def test_scaffold_apply_creates_directories(tmp_path: Path) -> None:
-    """ScaffoldPipeline.apply() создаёт директории и возвращает status='created'."""
+    """ScaffoldPipeline.apply() creates directories and returns status='created'."""
     from rdt.artifacts import DirectoryDef, ScaffoldPipeline
     dirs = [
         DirectoryDef(relative_path="logstash/pipeline"),
@@ -769,7 +815,7 @@ def test_scaffold_apply_creates_directories(tmp_path: Path) -> None:
 
 
 def test_scaffold_apply_skip_existing(tmp_path: Path) -> None:
-    """ScaffoldPipeline.apply() возвращает status='already_exists' для существующих директорий."""
+    """ScaffoldPipeline.apply() returns status='already_exists' for existing directories."""
     from rdt.artifacts import DirectoryDef, ScaffoldPipeline
     existing = tmp_path / "nginx"
     existing.mkdir()
@@ -782,21 +828,21 @@ def test_scaffold_apply_skip_existing(tmp_path: Path) -> None:
 
 
 def test_scaffold_has_errors_false(tmp_path: Path) -> None:
-    """ScaffoldPipeline.has_errors() возвращает False при успешных результатах."""
+    """ScaffoldPipeline.has_errors() returns False for successful results."""
     from rdt.artifacts import DirectoryDef, ScaffoldPipeline, ScaffoldResult
     results = [ScaffoldResult(path=tmp_path / "a", status="created")]
     assert ScaffoldPipeline.has_errors(results) is False
 
 
 def test_scaffold_has_errors_true(tmp_path: Path) -> None:
-    """ScaffoldPipeline.has_errors() возвращает True если есть ошибка."""
+    """ScaffoldPipeline.has_errors() returns True when there is an error."""
     from rdt.artifacts import ScaffoldPipeline, ScaffoldResult
     results = [ScaffoldResult(path=tmp_path / "a", status="error", error="permission denied")]
     assert ScaffoldPipeline.has_errors(results) is True
 
 
 def test_scaffold_multiple_mixed(tmp_path: Path) -> None:
-    """ScaffoldPipeline обрабатывает mix новых и существующих директорий."""
+    """ScaffoldPipeline handles a mix of new and existing directories."""
     from rdt.artifacts import DirectoryDef, ScaffoldPipeline
     existing = tmp_path / "existing"
     existing.mkdir()
@@ -812,11 +858,11 @@ def test_scaffold_multiple_mixed(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# P2: BootstrapHint — разграничение bootstrap/artifact
+# P2: BootstrapHint — bootstrap/artifact separation
 # ---------------------------------------------------------------------------
 
 def test_bootstrap_hint_fields() -> None:
-    """BootstrapHint хранит message и опциональный command."""
+    """BootstrapHint stores message and an optional command."""
     from rdt.artifacts import BootstrapHint
     hint = BootstrapHint(message="Run init script", command="docker exec -it svc init.sh")
     assert hint.message == "Run init script"
@@ -824,7 +870,7 @@ def test_bootstrap_hint_fields() -> None:
 
 
 def test_bootstrap_hint_without_command() -> None:
-    """BootstrapHint работает без команды."""
+    """BootstrapHint works without a command."""
     from rdt.artifacts import BootstrapHint
     hint = BootstrapHint(message="Check logs manually")
     assert hint.message == "Check logs manually"
@@ -832,7 +878,7 @@ def test_bootstrap_hint_without_command() -> None:
 
 
 def test_service_preset_has_scaffolds_and_hints() -> None:
-    """ServicePreset.scaffolds и bootstrap_hints доступны и имеют правильные типы."""
+    """ServicePreset.scaffolds and bootstrap_hints are available and have correct types."""
     from rdt.presets.catalog import LOGSTASH
     from rdt.artifacts import DirectoryDef, BootstrapHint
     assert len(LOGSTASH.scaffolds) >= 2
@@ -842,7 +888,7 @@ def test_service_preset_has_scaffolds_and_hints() -> None:
 
 
 def test_service_preset_scaffolds_paths() -> None:
-    """LOGSTASH пресет декларирует корректные пути директорий."""
+    """LOGSTASH preset declares correct directory paths."""
     from rdt.presets.catalog import LOGSTASH
     paths = [d.relative_path for d in LOGSTASH.scaffolds]
     assert "logstash/pipeline" in paths
@@ -850,7 +896,7 @@ def test_service_preset_scaffolds_paths() -> None:
 
 
 def test_logstash_scaffold_creates_dirs(tmp_path: Path) -> None:
-    """ScaffoldPipeline + LOGSTASH.scaffolds создаёт logstash/pipeline и logstash/config."""
+    """ScaffoldPipeline + LOGSTASH.scaffolds creates logstash/pipeline and logstash/config."""
     from rdt.artifacts import ScaffoldPipeline
     from rdt.presets.catalog import LOGSTASH
     sp = ScaffoldPipeline(LOGSTASH.scaffolds, tmp_path)
@@ -861,7 +907,7 @@ def test_logstash_scaffold_creates_dirs(tmp_path: Path) -> None:
 
 
 def test_preset_without_scaffolds_has_empty_list() -> None:
-    """ServicePreset без scaffolds имеет пустой список по умолчанию."""
+    """ServicePreset without scaffolds has an empty list by default."""
     from rdt.presets.catalog import POSTGRES
     assert POSTGRES.scaffolds == []
     assert POSTGRES.bootstrap_hints == []
@@ -872,9 +918,9 @@ def test_preset_without_scaffolds_has_empty_list() -> None:
 # ---------------------------------------------------------------------------
 
 def test_scaffold_error_detected_by_has_errors(tmp_path: Path) -> None:
-    """ScaffoldPipeline.has_errors() возвращает True если хотя бы одна директория не создана."""
+    """ScaffoldPipeline.has_errors() returns True when at least one directory was not created."""
     from rdt.artifacts import ScaffoldPipeline, ScaffoldResult
-    # Создаём результат с ошибкой напрямую
+    # Create an error result directly.
     error_result = ScaffoldResult(path=tmp_path / "bad", status="error", error="permission denied")
     ok_result = ScaffoldResult(path=tmp_path / "ok", status="created")
     assert ScaffoldPipeline.has_errors([error_result, ok_result]) is True
@@ -882,11 +928,11 @@ def test_scaffold_error_detected_by_has_errors(tmp_path: Path) -> None:
 
 
 def test_scaffold_apply_returns_error_on_permission_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """ScaffoldPipeline.apply() возвращает status='error' если mkdir бросает исключение."""
+    """ScaffoldPipeline.apply() returns status='error' when mkdir raises an exception."""
     from rdt.artifacts import DirectoryDef, ScaffoldPipeline
     import pathlib
 
-    # Патчим Path.mkdir чтобы бросал PermissionError
+    # Patch Path.mkdir to raise PermissionError.
     original_mkdir = pathlib.Path.mkdir
 
     def mock_mkdir(self, *args, **kwargs):
@@ -908,26 +954,23 @@ def test_scaffold_apply_returns_error_on_permission_failure(tmp_path: Path, monk
 # ---------------------------------------------------------------------------
 
 def test_rollback_restores_compose(tmp_path: Path) -> None:
-    """_do_rollback восстанавливает compose файл из снимка."""
-    from rich.console import Console
-    from rdt.cli import _do_rollback
+    """_rollback restores the compose file from a snapshot."""
+    from rdt.core import _rollback
 
     compose_file = tmp_path / "docker-compose.yml"
     original = "version: '3'\nservices: {}\n"
     compose_file.write_text(original + "# modified\n", encoding="utf-8")
 
-    console = Console(quiet=True)
-    _do_rollback(
-        console=console,
+    _rollback(
         compose_file=compose_file,
         compose_was_new=False,
         compose_snapshot=original,
         env_file=tmp_path / ".env",
-        env_existed_before=False,
+        env_existed=False,
         env_snapshot=None,
-        env_example_file=tmp_path / ".env.example",
-        env_example_existed_before=False,
-        env_example_snapshot=None,
+        env_example=tmp_path / ".env.example",
+        env_ex_existed=False,
+        env_ex_snapshot=None,
         scaffold_results=[],
         artifact_results=[],
     )
@@ -935,25 +978,22 @@ def test_rollback_restores_compose(tmp_path: Path) -> None:
 
 
 def test_rollback_removes_new_compose(tmp_path: Path) -> None:
-    """_do_rollback удаляет compose файл если он был создан в текущем запуске."""
-    from rich.console import Console
-    from rdt.cli import _do_rollback
+    """_rollback removes the compose file if it was created in the current run."""
+    from rdt.core import _rollback
 
     compose_file = tmp_path / "docker-compose.yml"
     compose_file.write_text("new content", encoding="utf-8")
 
-    console = Console(quiet=True)
-    _do_rollback(
-        console=console,
+    _rollback(
         compose_file=compose_file,
         compose_was_new=True,
         compose_snapshot=None,
         env_file=tmp_path / ".env",
-        env_existed_before=False,
+        env_existed=False,
         env_snapshot=None,
-        env_example_file=tmp_path / ".env.example",
-        env_example_existed_before=False,
-        env_example_snapshot=None,
+        env_example=tmp_path / ".env.example",
+        env_ex_existed=False,
+        env_ex_snapshot=None,
         scaffold_results=[],
         artifact_results=[],
     )
@@ -961,9 +1001,8 @@ def test_rollback_removes_new_compose(tmp_path: Path) -> None:
 
 
 def test_rollback_removes_created_artifact(tmp_path: Path) -> None:
-    """_do_rollback удаляет созданные артефакты (status='created')."""
-    from rich.console import Console
-    from rdt.cli import _do_rollback
+    """_rollback removes created artifacts (status='created')."""
+    from rdt.core import _rollback
     from rdt.artifacts import ArtifactResult
 
     artifact_file = tmp_path / "nginx" / "nginx.conf"
@@ -972,18 +1011,16 @@ def test_rollback_removes_created_artifact(tmp_path: Path) -> None:
 
     results = [ArtifactResult(path=artifact_file, status="created")]
 
-    console = Console(quiet=True)
-    _do_rollback(
-        console=console,
+    _rollback(
         compose_file=tmp_path / "docker-compose.yml",
         compose_was_new=False,
         compose_snapshot=None,
         env_file=tmp_path / ".env",
-        env_existed_before=True,
+        env_existed=True,
         env_snapshot=None,
-        env_example_file=tmp_path / ".env.example",
-        env_example_existed_before=True,
-        env_example_snapshot=None,
+        env_example=tmp_path / ".env.example",
+        env_ex_existed=True,
+        env_ex_snapshot=None,
         scaffold_results=[],
         artifact_results=results,
     )
@@ -991,9 +1028,8 @@ def test_rollback_removes_created_artifact(tmp_path: Path) -> None:
 
 
 def test_rollback_removes_empty_scaffold_dir(tmp_path: Path) -> None:
-    """_do_rollback удаляет пустые scaffold-директории (status='created')."""
-    from rich.console import Console
-    from rdt.cli import _do_rollback
+    """_rollback removes empty scaffold directories (status='created')."""
+    from rdt.core import _rollback
     from rdt.artifacts import ScaffoldResult
 
     scaffold_dir = tmp_path / "logstash" / "pipeline"
@@ -1001,18 +1037,16 @@ def test_rollback_removes_empty_scaffold_dir(tmp_path: Path) -> None:
 
     results = [ScaffoldResult(path=scaffold_dir, status="created")]
 
-    console = Console(quiet=True)
-    _do_rollback(
-        console=console,
+    _rollback(
         compose_file=tmp_path / "docker-compose.yml",
         compose_was_new=False,
         compose_snapshot=None,
         env_file=tmp_path / ".env",
-        env_existed_before=True,
+        env_existed=True,
         env_snapshot=None,
-        env_example_file=tmp_path / ".env.example",
-        env_example_existed_before=True,
-        env_example_snapshot=None,
+        env_example=tmp_path / ".env.example",
+        env_ex_existed=True,
+        env_ex_snapshot=None,
         scaffold_results=results,
         artifact_results=[],
     )
@@ -1020,9 +1054,8 @@ def test_rollback_removes_empty_scaffold_dir(tmp_path: Path) -> None:
 
 
 def test_rollback_does_not_remove_nonempty_scaffold_dir(tmp_path: Path) -> None:
-    """_do_rollback не удаляет непустые scaffold-директории."""
-    from rich.console import Console
-    from rdt.cli import _do_rollback
+    """_rollback does not remove non-empty scaffold directories."""
+    from rdt.core import _rollback
     from rdt.artifacts import ScaffoldResult
 
     scaffold_dir = tmp_path / "logstash" / "pipeline"
@@ -1031,18 +1064,16 @@ def test_rollback_does_not_remove_nonempty_scaffold_dir(tmp_path: Path) -> None:
 
     results = [ScaffoldResult(path=scaffold_dir, status="created")]
 
-    console = Console(quiet=True)
-    _do_rollback(
-        console=console,
+    _rollback(
         compose_file=tmp_path / "docker-compose.yml",
         compose_was_new=False,
         compose_snapshot=None,
         env_file=tmp_path / ".env",
-        env_existed_before=True,
+        env_existed=True,
         env_snapshot=None,
-        env_example_file=tmp_path / ".env.example",
-        env_example_existed_before=True,
-        env_example_snapshot=None,
+        env_example=tmp_path / ".env.example",
+        env_ex_existed=True,
+        env_ex_snapshot=None,
         scaffold_results=results,
         artifact_results=[],
     )
@@ -1055,7 +1086,7 @@ def test_rollback_does_not_remove_nonempty_scaffold_dir(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 def test_kibana_preset_exists() -> None:
-    """KIBANA пресет присутствует в каталоге и имеет правильные базовые поля."""
+    """KIBANA preset exists in the catalog and has correct base fields."""
     from rdt.presets.catalog import ALL_PRESETS, KIBANA
     assert "kibana" in ALL_PRESETS
     assert ALL_PRESETS["kibana"] is KIBANA
@@ -1066,7 +1097,7 @@ def test_kibana_preset_exists() -> None:
 
 
 def test_kibana_preset_env_contains_required_keys() -> None:
-    """KIBANA пресет содержит обязательные переменные окружения."""
+    """KIBANA preset contains required environment variables."""
     from rdt.presets.catalog import KIBANA
     env_keys = set(KIBANA.default_env.keys())
     assert "ELASTICSEARCH_HOSTS" in env_keys
@@ -1075,7 +1106,7 @@ def test_kibana_preset_env_contains_required_keys() -> None:
 
 
 def test_kibana_smart_mapping_detects_elasticsearch() -> None:
-    """Kibana Smart Mapping корректно подхватывает elasticsearch сервис."""
+    """Kibana Smart Mapping correctly picks up the elasticsearch service."""
     from rdt.smart_mapping import apply_smart_mapping, get_candidate_parents
     existing = ["elasticsearch"]
     candidates = get_candidate_parents("kibana", existing)
@@ -1088,7 +1119,7 @@ def test_kibana_smart_mapping_detects_elasticsearch() -> None:
 
 
 def test_kibana_smart_mapping_detects_opensearch() -> None:
-    """Kibana Smart Mapping корректно подхватывает opensearch сервис."""
+    """Kibana Smart Mapping correctly picks up the opensearch service."""
     from rdt.smart_mapping import apply_smart_mapping, get_candidate_parents
     existing = ["opensearch"]
     candidates = get_candidate_parents("kibana", existing)
@@ -1100,7 +1131,7 @@ def test_kibana_smart_mapping_detects_opensearch() -> None:
 
 
 def test_kibana_smart_mapping_noop_without_es() -> None:
-    """Kibana Smart Mapping не добавляет зависимостей если нет ES/OpenSearch."""
+    """Kibana Smart Mapping does not add dependencies when ES/OpenSearch is missing."""
     from rdt.smart_mapping import apply_smart_mapping, get_candidate_parents
     existing = ["postgres", "redis"]
     candidates = get_candidate_parents("kibana", existing)
@@ -1112,14 +1143,14 @@ def test_kibana_smart_mapping_noop_without_es() -> None:
 
 
 def test_kibana_env_defaults_registered() -> None:
-    """SERVICE_DEFAULTS содержит значения для Kibana credentials."""
+    """SERVICE_DEFAULTS contains values for Kibana credentials."""
     from rdt.env_manager import SERVICE_DEFAULTS
     assert "KIBANA_SYSTEM_PASSWORD" in SERVICE_DEFAULTS
     assert "KIBANA_ENCRYPTION_KEY" in SERVICE_DEFAULTS
 
 
 def test_kibana_preset_has_bootstrap_hint() -> None:
-    """KIBANA пресет содержит bootstrap-подсказку для настройки kibana_system пользователя."""
+    """KIBANA preset contains a bootstrap hint for configuring the kibana_system user."""
     from rdt.presets.catalog import KIBANA
     assert len(KIBANA.bootstrap_hints) >= 1
     hint = KIBANA.bootstrap_hints[0]
@@ -1131,7 +1162,7 @@ def test_kibana_preset_has_bootstrap_hint() -> None:
 # ---------------------------------------------------------------------------
 
 def test_seq_preset_exists() -> None:
-    """SEQ пресет присутствует в каталоге и имеет правильные базовые поля."""
+    """SEQ preset exists in the catalog and has correct base fields."""
     from rdt.presets.catalog import ALL_PRESETS, SEQ
     assert "seq" in ALL_PRESETS
     assert ALL_PRESETS["seq"] is SEQ
@@ -1140,27 +1171,27 @@ def test_seq_preset_exists() -> None:
 
 
 def test_seq_preset_env_contains_accept_eula() -> None:
-    """SEQ пресет содержит ACCEPT_EULA в переменных окружения."""
+    """SEQ preset contains ACCEPT_EULA in environment variables."""
     from rdt.presets.catalog import SEQ
     assert "ACCEPT_EULA" in SEQ.default_env
     assert SEQ.default_env["ACCEPT_EULA"] == "Y"
 
 
 def test_seq_preset_no_artifacts() -> None:
-    """SEQ пресет не требует companion-артефактов."""
+    """SEQ preset does not require companion artifacts."""
     from rdt.presets.catalog import SEQ
     assert SEQ.artifacts == []
     assert SEQ.scaffolds == []
 
 
 def test_seq_preset_has_volume() -> None:
-    """SEQ пресет объявляет volume для персистентного хранилища."""
+    """SEQ preset declares a volume for persistent storage."""
     from rdt.presets.catalog import SEQ
     assert len(SEQ.volumes) >= 1
 
 
 def test_seq_preset_has_bootstrap_hint() -> None:
-    """SEQ пресет содержит bootstrap-подсказку."""
+    """SEQ preset contains a bootstrap hint."""
     from rdt.presets.catalog import SEQ
     assert len(SEQ.bootstrap_hints) >= 1
 
@@ -1170,7 +1201,7 @@ def test_seq_preset_has_bootstrap_hint() -> None:
 # ---------------------------------------------------------------------------
 
 def test_filebeat_preset_exists() -> None:
-    """FILEBEAT пресет присутствует в каталоге и имеет правильные базовые поля."""
+    """FILEBEAT preset exists in the catalog and has correct base fields."""
     from rdt.presets.catalog import ALL_PRESETS, FILEBEAT
     assert "filebeat" in ALL_PRESETS
     assert ALL_PRESETS["filebeat"] is FILEBEAT
@@ -1180,7 +1211,7 @@ def test_filebeat_preset_exists() -> None:
 
 
 def test_filebeat_preset_has_volumes() -> None:
-    """FILEBEAT пресет объявляет volumes для config и data."""
+    """FILEBEAT preset declares volumes for config and data."""
     from rdt.presets.catalog import FILEBEAT
     assert len(FILEBEAT.volumes) >= 2
     volume_str = " ".join(FILEBEAT.volumes)
@@ -1189,7 +1220,7 @@ def test_filebeat_preset_has_volumes() -> None:
 
 
 def test_filebeat_preset_has_artifacts() -> None:
-    """FILEBEAT пресет содержит 3 conditional артефакта (logstash / es / stdout)."""
+    """FILEBEAT preset contains 3 conditional artifacts (logstash / es / stdout)."""
     from rdt.presets.catalog import FILEBEAT
     assert len(FILEBEAT.artifacts) == 3
     conditions = {a.condition for a in FILEBEAT.artifacts}
@@ -1199,7 +1230,7 @@ def test_filebeat_preset_has_artifacts() -> None:
 
 
 def test_filebeat_preset_has_scaffold() -> None:
-    """FILEBEAT пресет декларирует scaffold-директорию filebeat/."""
+    """FILEBEAT preset declares the filebeat/ scaffold directory."""
     from rdt.presets.catalog import FILEBEAT
     from rdt.artifacts import DirectoryDef
     assert len(FILEBEAT.scaffolds) >= 1
@@ -1209,13 +1240,13 @@ def test_filebeat_preset_has_scaffold() -> None:
 
 
 def test_filebeat_preset_has_bootstrap_hints() -> None:
-    """FILEBEAT пресет содержит bootstrap-подсказки."""
+    """FILEBEAT preset contains bootstrap hints."""
     from rdt.presets.catalog import FILEBEAT
     assert len(FILEBEAT.bootstrap_hints) >= 1
 
 
 # ---------------------------------------------------------------------------
-# Filebeat — шаблоны
+# Filebeat — templates
 # ---------------------------------------------------------------------------
 
 FILEBEAT_ANSWERS_LOGSTASH = {
@@ -1264,7 +1295,7 @@ def _make_filebeat_context(base_dir: Path, answers: dict) -> ArtifactContext:
 
 
 def test_filebeat_logstash_template_created(tmp_path: Path) -> None:
-    """filebeat-logstash.yml.j2 создаётся и содержит logstash host."""
+    """filebeat-logstash.yml.j2 is created and contains the logstash host."""
     artifact = ArtifactDef(
         relative_path="filebeat/filebeat.yml",
         source_template="filebeat/filebeat-logstash.yml.j2",
@@ -1284,7 +1315,7 @@ def test_filebeat_logstash_template_created(tmp_path: Path) -> None:
 
 
 def test_filebeat_es_template_created(tmp_path: Path) -> None:
-    """filebeat-es.yml.j2 создаётся и содержит elasticsearch host."""
+    """filebeat-es.yml.j2 is created and contains the elasticsearch host."""
     artifact = ArtifactDef(
         relative_path="filebeat/filebeat.yml",
         source_template="filebeat/filebeat-es.yml.j2",
@@ -1303,7 +1334,7 @@ def test_filebeat_es_template_created(tmp_path: Path) -> None:
 
 
 def test_filebeat_stdout_template_created(tmp_path: Path) -> None:
-    """filebeat-stdout.yml.j2 создаётся для debug-режима."""
+    """filebeat-stdout.yml.j2 is created for debug mode."""
     artifact = ArtifactDef(
         relative_path="filebeat/filebeat.yml",
         source_template="filebeat/filebeat-stdout.yml.j2",
@@ -1321,7 +1352,7 @@ def test_filebeat_stdout_template_created(tmp_path: Path) -> None:
 
 
 def test_filebeat_logstash_template_skipped_in_es_mode(tmp_path: Path) -> None:
-    """Логстэш-артефакт неактивен когда выбран elasticsearch-режим."""
+    """Logstash artifact is inactive when elasticsearch mode is selected."""
     artifact = ArtifactDef(
         relative_path="filebeat/filebeat.yml",
         source_template="filebeat/filebeat-logstash.yml.j2",
@@ -1331,11 +1362,11 @@ def test_filebeat_logstash_template_skipped_in_es_mode(tmp_path: Path) -> None:
     ctx = _make_filebeat_context(tmp_path, FILEBEAT_ANSWERS_ES)
     pipeline = ArtifactPipeline([artifact], ctx)
     plans = pipeline.plan()
-    assert len(plans) == 0  # условие не выполнено → неактивен
+    assert len(plans) == 0  # condition is not met → inactive
 
 
 def test_filebeat_conditional_only_one_active(tmp_path: Path) -> None:
-    """Из трёх conditional артефактов активен ровно один при logstash-режиме."""
+    """Exactly one of three conditional artifacts is active in logstash mode."""
     from rdt.presets.catalog import FILEBEAT
     ctx = _make_filebeat_context(tmp_path, FILEBEAT_ANSWERS_LOGSTASH)
     pipeline = ArtifactPipeline(FILEBEAT.artifacts, ctx)
@@ -1345,7 +1376,7 @@ def test_filebeat_conditional_only_one_active(tmp_path: Path) -> None:
 
 
 def test_filebeat_kibana_host_rendered_in_logstash_template(tmp_path: Path) -> None:
-    """setup.kibana секция появляется когда filebeat_kibana_host задан."""
+    """setup.kibana section appears when filebeat_kibana_host is set."""
     answers = {**FILEBEAT_ANSWERS_LOGSTASH, "filebeat_kibana_host": "kibana:5601"}
     artifact = ArtifactDef(
         relative_path="filebeat/filebeat.yml",
@@ -1362,7 +1393,7 @@ def test_filebeat_kibana_host_rendered_in_logstash_template(tmp_path: Path) -> N
 
 
 def test_filebeat_kibana_section_absent_when_no_host(tmp_path: Path) -> None:
-    """setup.kibana секция отсутствует когда filebeat_kibana_host пустой."""
+    """setup.kibana section is absent when filebeat_kibana_host is empty."""
     artifact = ArtifactDef(
         relative_path="filebeat/filebeat.yml",
         source_template="filebeat/filebeat-logstash.yml.j2",
@@ -1381,7 +1412,7 @@ def test_filebeat_kibana_section_absent_when_no_host(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 def test_filebeat_smart_mapping_prefers_logstash() -> None:
-    """Filebeat smart mapping выбирает Logstash при наличии и Logstash и ES."""
+    """Filebeat smart mapping chooses Logstash when both Logstash and ES exist."""
     from rdt.smart_mapping import apply_smart_mapping
     answers: dict = {}
     result = apply_smart_mapping("filebeat", ["elasticsearch", "logstash"], answers)
@@ -1393,7 +1424,7 @@ def test_filebeat_smart_mapping_prefers_logstash() -> None:
 
 
 def test_filebeat_smart_mapping_falls_back_to_es() -> None:
-    """Filebeat smart mapping выбирает ES если Logstash отсутствует."""
+    """Filebeat smart mapping chooses ES when Logstash is absent."""
     from rdt.smart_mapping import apply_smart_mapping
     answers: dict = {}
     result = apply_smart_mapping("filebeat", ["elasticsearch", "redis"], answers)
@@ -1404,7 +1435,7 @@ def test_filebeat_smart_mapping_falls_back_to_es() -> None:
 
 
 def test_filebeat_smart_mapping_falls_back_to_opensearch() -> None:
-    """Filebeat smart mapping работает с opensearch."""
+    """Filebeat smart mapping works with opensearch."""
     from rdt.smart_mapping import apply_smart_mapping
     answers: dict = {}
     result = apply_smart_mapping("filebeat", ["opensearch"], answers)
@@ -1413,7 +1444,7 @@ def test_filebeat_smart_mapping_falls_back_to_opensearch() -> None:
 
 
 def test_filebeat_smart_mapping_stdout_when_no_target() -> None:
-    """Filebeat smart mapping выбирает stdout если нет ни Logstash ни ES."""
+    """Filebeat smart mapping chooses stdout when neither Logstash nor ES exists."""
     from rdt.smart_mapping import apply_smart_mapping
     answers: dict = {}
     result = apply_smart_mapping("filebeat", ["redis", "postgres"], answers)
@@ -1422,7 +1453,7 @@ def test_filebeat_smart_mapping_stdout_when_no_target() -> None:
 
 
 def test_filebeat_smart_mapping_detects_kibana() -> None:
-    """Filebeat smart mapping добавляет Kibana host если Kibana присутствует."""
+    """Filebeat smart mapping adds Kibana host when Kibana is present."""
     from rdt.smart_mapping import apply_smart_mapping
     answers: dict = {}
     result = apply_smart_mapping("filebeat", ["logstash", "kibana"], answers)
@@ -1431,7 +1462,7 @@ def test_filebeat_smart_mapping_detects_kibana() -> None:
 
 
 def test_filebeat_get_candidate_parents() -> None:
-    """get_candidate_parents возвращает Logstash / ES / OpenSearch / Kibana для filebeat."""
+    """get_candidate_parents returns Logstash / ES / OpenSearch / Kibana for filebeat."""
     from rdt.smart_mapping import get_candidate_parents
     existing = ["logstash", "elasticsearch", "opensearch", "kibana", "redis"]
     candidates = get_candidate_parents("filebeat", existing)
@@ -1443,7 +1474,7 @@ def test_filebeat_get_candidate_parents() -> None:
 
 
 def test_filebeat_scaffold_creates_dir(tmp_path: Path) -> None:
-    """ScaffoldPipeline + FILEBEAT.scaffolds создаёт filebeat/."""
+    """ScaffoldPipeline + FILEBEAT.scaffolds creates filebeat/."""
     from rdt.artifacts import ScaffoldPipeline
     from rdt.presets.catalog import FILEBEAT
     sp = ScaffoldPipeline(FILEBEAT.scaffolds, tmp_path)
@@ -1458,7 +1489,7 @@ def test_filebeat_scaffold_creates_dir(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 def test_traefik_preset_exists() -> None:
-    """TRAEFIK пресет присутствует в каталоге и имеет правильные базовые поля."""
+    """TRAEFIK preset exists in the catalog and has correct base fields."""
     from rdt.presets.catalog import ALL_PRESETS, TRAEFIK
     assert "traefik" in ALL_PRESETS
     assert ALL_PRESETS["traefik"] is TRAEFIK
@@ -1469,7 +1500,7 @@ def test_traefik_preset_exists() -> None:
 
 
 def test_traefik_preset_has_artifact() -> None:
-    """TRAEFIK пресет содержит ровно один companion-артефакт (traefik.yml)."""
+    """TRAEFIK preset contains exactly one companion artifact (traefik.yml)."""
     from rdt.presets.catalog import TRAEFIK
     assert len(TRAEFIK.artifacts) == 1
     art = TRAEFIK.artifacts[0]
@@ -1478,7 +1509,7 @@ def test_traefik_preset_has_artifact() -> None:
 
 
 def test_traefik_preset_has_scaffolds() -> None:
-    """TRAEFIK пресет декларирует scaffold-директории traefik/ и traefik/dynamic/."""
+    """TRAEFIK preset declares traefik/ and traefik/dynamic/ scaffold directories."""
     from rdt.presets.catalog import TRAEFIK
     from rdt.artifacts import DirectoryDef
     assert len(TRAEFIK.scaffolds) >= 2
@@ -1489,13 +1520,13 @@ def test_traefik_preset_has_scaffolds() -> None:
 
 
 def test_traefik_preset_has_bootstrap_hints() -> None:
-    """TRAEFIK пресет содержит не менее трёх bootstrap-подсказок."""
+    """TRAEFIK preset contains at least three bootstrap hints."""
     from rdt.presets.catalog import TRAEFIK
     assert len(TRAEFIK.bootstrap_hints) >= 3
 
 
 def test_traefik_preset_empty_env() -> None:
-    """TRAEFIK пресет не имеет обязательных env-переменных (Traefik конфигурируется через YAML)."""
+    """TRAEFIK preset has no required env variables (Traefik is configured via YAML)."""
     from rdt.presets.catalog import TRAEFIK
     assert TRAEFIK.default_env == {}
 
@@ -1531,18 +1562,18 @@ TRAEFIK_ANSWERS_HTTPS = {
 
 
 def test_traefik_strategy_ports_basic() -> None:
-    """TraefikStrategy добавляет порты 80 и 8080 в базовом режиме."""
+    """TraefikStrategy adds ports 80 and 8080 in basic mode."""
     strategy = _make_traefik_strategy(TRAEFIK_ANSWERS_BASIC)
     service: dict = {}
     strategy._enrich(service)
     assert "80:80" in service["ports"]
     assert "8080:8080" in service["ports"]
-    # HTTPS не включён — порт 443 не должен быть
+    # HTTPS is disabled, so port 443 must be absent.
     assert not any("443" in p for p in service["ports"])
 
 
 def test_traefik_strategy_ports_https() -> None:
-    """TraefikStrategy добавляет порт 443 когда HTTPS включён."""
+    """TraefikStrategy adds port 443 when HTTPS is enabled."""
     strategy = _make_traefik_strategy(TRAEFIK_ANSWERS_HTTPS)
     service: dict = {}
     strategy._enrich(service)
@@ -1550,7 +1581,7 @@ def test_traefik_strategy_ports_https() -> None:
 
 
 def test_traefik_strategy_volumes_basic() -> None:
-    """TraefikStrategy монтирует docker.sock и traefik.yml (без certs в базовом режиме)."""
+    """TraefikStrategy mounts docker.sock and traefik.yml without certs in basic mode."""
     strategy = _make_traefik_strategy(TRAEFIK_ANSWERS_BASIC)
     service: dict = {}
     strategy._enrich(service)
@@ -1561,7 +1592,7 @@ def test_traefik_strategy_volumes_basic() -> None:
 
 
 def test_traefik_strategy_volumes_https() -> None:
-    """TraefikStrategy добавляет certs-volume при включённом HTTPS."""
+    """TraefikStrategy adds a certs volume when HTTPS is enabled."""
     strategy = _make_traefik_strategy(TRAEFIK_ANSWERS_HTTPS)
     service: dict = {}
     strategy._enrich(service)
@@ -1570,7 +1601,7 @@ def test_traefik_strategy_volumes_https() -> None:
 
 
 def test_traefik_strategy_healthcheck() -> None:
-    """TraefikStrategy устанавливает healthcheck через /ping эндпоинт."""
+    """TraefikStrategy sets healthcheck through the /ping endpoint."""
     strategy = _make_traefik_strategy(TRAEFIK_ANSWERS_BASIC)
     service: dict = {}
     strategy._enrich(service)
@@ -1581,7 +1612,7 @@ def test_traefik_strategy_healthcheck() -> None:
 
 
 def test_traefik_strategy_no_ports_when_host_network() -> None:
-    """TraefikStrategy не добавляет ports если network_type=host."""
+    """TraefikStrategy does not add ports when network_type=host."""
     answers = {**TRAEFIK_ANSWERS_BASIC, "network_type": "host"}
     strategy = _make_traefik_strategy(answers)
     service: dict = {}
@@ -1590,7 +1621,7 @@ def test_traefik_strategy_no_ports_when_host_network() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Traefik — шаблон traefik.yml.j2
+# Traefik — traefik.yml.j2 template
 # ---------------------------------------------------------------------------
 
 def _make_traefik_artifact_context(base_dir: Path, answers: dict) -> ArtifactContext:
@@ -1609,7 +1640,7 @@ def _make_traefik_artifact_context(base_dir: Path, answers: dict) -> ArtifactCon
 
 
 def test_traefik_yml_template_created_basic(tmp_path: Path) -> None:
-    """traefik.yml.j2 рендерится корректно в базовом режиме (без HTTPS)."""
+    """traefik.yml.j2 renders correctly in basic mode (without HTTPS)."""
     artifact = ArtifactDef(
         relative_path="traefik/traefik.yml",
         source_template="traefik/traefik.yml.j2",
@@ -1629,7 +1660,7 @@ def test_traefik_yml_template_created_basic(tmp_path: Path) -> None:
 
 
 def test_traefik_yml_template_no_https_block_when_disabled(tmp_path: Path) -> None:
-    """traefik.yml.j2 не содержит certificatesResolvers если HTTPS отключён."""
+    """traefik.yml.j2 does not contain certificatesResolvers when HTTPS is disabled."""
     artifact = ArtifactDef(
         relative_path="traefik/traefik.yml",
         source_template="traefik/traefik.yml.j2",
@@ -1645,7 +1676,7 @@ def test_traefik_yml_template_no_https_block_when_disabled(tmp_path: Path) -> No
 
 
 def test_traefik_yml_template_has_https_block_when_enabled(tmp_path: Path) -> None:
-    """traefik.yml.j2 содержит websecure и certificatesResolvers при HTTPS."""
+    """traefik.yml.j2 contains websecure and certificatesResolvers with HTTPS."""
     artifact = ArtifactDef(
         relative_path="traefik/traefik.yml",
         source_template="traefik/traefik.yml.j2",
@@ -1667,7 +1698,7 @@ def test_traefik_yml_template_has_https_block_when_enabled(tmp_path: Path) -> No
 # ---------------------------------------------------------------------------
 
 def test_traefik_scaffold_creates_dirs(tmp_path: Path) -> None:
-    """ScaffoldPipeline + TRAEFIK.scaffolds создаёт traefik/ и traefik/dynamic/."""
+    """ScaffoldPipeline + TRAEFIK.scaffolds creates traefik/ and traefik/dynamic/."""
     from rdt.artifacts import ScaffoldPipeline
     from rdt.presets.catalog import TRAEFIK
     sp = ScaffoldPipeline(TRAEFIK.scaffolds, tmp_path)
@@ -1682,7 +1713,7 @@ def test_traefik_scaffold_creates_dirs(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 def test_dict_to_commented_healthcheck_test_flow_style() -> None:
-    """healthcheck.test сериализуется в inline (flow) стиле."""
+    """healthcheck.test is serialized in inline flow style."""
     from rdt.yaml_manager import _dict_to_commented
     from ruamel.yaml.comments import CommentedSeq
 
@@ -1705,7 +1736,7 @@ def test_dict_to_commented_healthcheck_test_flow_style() -> None:
 
 
 def test_save_compose_healthcheck_test_inline(tmp_path: Path) -> None:
-    """save_compose записывает healthcheck.test как inline-массив."""
+    """save_compose writes healthcheck.test as an inline array."""
     from rdt.yaml_manager import save_compose, make_base_compose, inject_service
 
     data = make_base_compose()
@@ -1728,13 +1759,13 @@ def test_save_compose_healthcheck_test_inline(tmp_path: Path) -> None:
     content = compose_file.read_text(encoding="utf-8")
 
     assert "test: [CMD-SHELL, pg_isready -U postgres || exit 1]" in content
-    assert "ports:\n    - " in content  # block-style под services.db
+    assert "ports:\n    - " in content  # block-style under services.db
     assert "volumes:\n    - pg_data:/var/lib/postgresql/data" in content
     assert "networks:\n    - rambo-net" in content
 
 
 def test_save_compose_normalizes_existing_healthcheck_test(tmp_path: Path) -> None:
-    """save_compose нормализует уже загруженные block-style healthcheck.test."""
+    """save_compose normalizes already loaded block-style healthcheck.test."""
     from rdt.yaml_manager import save_compose, load_compose
 
     compose_file = tmp_path / "docker-compose.yml"
@@ -1761,7 +1792,7 @@ services:
 
 
 def test_save_compose_traefik_healthcheck_inline(tmp_path: Path) -> None:
-    """TraefikStrategy + save_compose даёт inline healthcheck.test."""
+    """TraefikStrategy + save_compose produces inline healthcheck.test."""
     from rdt.strategies.traefik import TraefikStrategy
     from rdt.presets.catalog import TRAEFIK
     from rdt.yaml_manager import save_compose, make_base_compose, inject_service


### PR DESCRIPTION
- Convert all docstrings and comments from Russian to English across all core modules
- Update inline comments in rdt/artifacts.py, rdt/cli.py, rdt/core.py, rdt/doctor.py
- Standardize comments in rdt/env_manager.py, rdt/mcp_server.py, rdt/port_utils.py
- Update strategy modules documentation (admin_tool, base, database, factory, monitoring, traefik, web_server)
- Refactor comments in rdt/smart_mapping.py, rdt/wizard.py, rdt/yaml_manager.py
- Update test documentation in test_artifact_pipeline.py
- Add CONTRIBUTING.md with contribution guidelines
- Minor documentation update to docs/en/scripting.md